### PR TITLE
fix test by adding toAlias field

### DIFF
--- a/tests/TKNotificationsTests.m
+++ b/tests/TKNotificationsTests.m
@@ -62,6 +62,7 @@ void check(NSString *message, BOOL condition) {
                                                           currency:@"USD"];
         builder.accountId = payerAccount.id;
         builder.redeemerAlias = payee.firstAlias;
+        builder.toAlias = payee.firstAlias;
         Token *token = [builder execute];
         
         token = [[payer endorseToken:token withKey:Key_Level_Standard] token];


### PR DESCRIPTION
needed to set the 'to' field in testTransfer when creating the transfer token so the notification arrives (due to gateway changes, it used to use the 'redeemer' but that was wrong, now uses 'to' instead).