### PR TITLE
fix tests to include to field in transfer tokens

### DIFF
--- a/tests/TKAccessRedemptionTests.m
+++ b/tests/TKAccessRedemptionTests.m
@@ -138,6 +138,7 @@
                                                           currency:@"USD"];
         builder.accountId = grantorAccount.id;
         builder.redeemerAlias = redeemer.firstAlias;
+        builder.toAlias = redeemer.firstAlias;
         Token *transferToken = [builder execute];
         
         transferToken = [[grantor endorseToken:transferToken withKey:Key_Level_Standard] token];
@@ -172,6 +173,7 @@
                                                           currency:@"USD"];
         builder.accountId = grantorAccount.id;
         builder.redeemerAlias = redeemer.firstAlias;
+        builder.toAlias = redeemer.firstAlias;
         Token *transferToken = [builder execute];
         transferToken = [[grantor endorseToken:transferToken withKey:Key_Level_Standard] token];
         

--- a/tests/TKNotificationsTests.m
+++ b/tests/TKNotificationsTests.m
@@ -147,6 +147,7 @@ void check(NSString *message, BOOL condition) {
                                                           currency:@"USD"];
         builder.accountId = payerAccount.id;
         builder.redeemerAlias = payee.firstAlias;
+        builder.toAlias = payee.firstAlias;
         Token *token = [builder execute];
         
         TokenOperationResult *result = [payer endorseToken:token withKey:Key_Level_Low];
@@ -213,6 +214,7 @@ void check(NSString *message, BOOL condition) {
                                                           currency:@"USD"];
         builder.accountId = payerAccount.id;
         builder.redeemerAlias = payee.firstAlias;
+        builder.toAlias = payee.firstAlias;
         Token *token = [builder execute];
         
         token = [[payer endorseToken:token withKey:Key_Level_Standard] token];

--- a/tests/TKTransactionsTests.m
+++ b/tests/TKTransactionsTests.m
@@ -50,6 +50,7 @@
                                                           currency:@"USD"];
         builder.accountId = payerAccount.id;
         builder.redeemerAlias = payee.firstAlias;
+        builder.toAlias = payee.firstAlias;
         Token *token = [builder execute];
         token = [[payer endorseToken:token withKey:Key_Level_Standard] token];
         
@@ -78,6 +79,7 @@
                                                           currency:@"USD"];
         builder.accountId = payerAccount.id;
         builder.redeemerAlias = payee.firstAlias;
+        builder.toAlias = payee.firstAlias;
         Token *token = [builder execute];
         token = [[payer endorseToken:token withKey:Key_Level_Standard] token];
         

--- a/tests/TKTransferTokenRedemptionTests.m
+++ b/tests/TKTransferTokenRedemptionTests.m
@@ -41,6 +41,7 @@
                                                           currency:@"USD"];
         builder.accountId = payerAccount.id;
         builder.redeemerAlias = payee.firstAlias;
+        builder.toAlias = payee.firstAlias;
         Token *token = [builder execute];
         TokenOperationResult *endorsedResult = [payer endorseToken:token withKey:Key_Level_Standard];
         token = [endorsedResult token];
@@ -69,6 +70,7 @@
                                                           currency:@"USD"];
         builder.bankAuthorization = [self createBankAuthorization:tokenIO memberId:payer.id];
         builder.redeemerAlias = payer.firstAlias;
+        builder.toAlias = payee.firstAlias;
         Token *token = [builder execute];
         TokenOperationResult *endorsedResult = [payer endorseToken:token withKey:Key_Level_Standard];
         token = [endorsedResult token];
@@ -100,6 +102,7 @@
                                                           currency:@"USD"];
         builder.accountId = payerAccount.id;
         builder.redeemerAlias = payee.firstAlias;
+        builder.toAlias = payee.firstAlias;
         Token *token = [builder execute];
         TokenOperationResult *endorsedResult = [payer endorseToken:token withKey:Key_Level_Standard];
         
@@ -135,6 +138,7 @@
                                                           currency:@"USD"];
         builder.accountId = payerAccount.id;
         builder.redeemerAlias = payee.firstAlias;
+        builder.toAlias = payee.firstAlias;
         builder.destinations = destinations;
         Token *token = [builder execute];
         TokenOperationResult *endorsedResult = [payer endorseToken:token withKey:Key_Level_Standard];
@@ -162,6 +166,7 @@
                                                           currency:@"USD"];
         builder.accountId = payerAccount.id;
         builder.redeemerAlias = payee.firstAlias;
+        builder.toAlias = payee.firstAlias;
         Token *token = [builder execute];
         TokenOperationResult *endorsedResult = [payer endorseToken:token withKey:Key_Level_Standard];
         token = [endorsedResult token];
@@ -184,6 +189,7 @@
                                                           currency:@"USD"];
         builder.accountId = payerAccount.id;
         builder.redeemerAlias = payee.firstAlias;
+        builder.toAlias = payee.firstAlias;
         Token *token = [builder execute];
         TokenOperationResult *endorsedResult = [payer endorseToken:token withKey:Key_Level_Standard];
         token = [endorsedResult token];

--- a/tests/TKTransferTokenTests.m
+++ b/tests/TKTransferTokenTests.m
@@ -44,6 +44,7 @@
                                                           currency:@"USD"];
         builder.accountId = payerAccount.id;
         builder.redeemerAlias = payee.firstAlias;
+        builder.toAlias = payee.firstAlias;
         builder.destinations = destinations;
         Token *token = [builder execute];
         
@@ -68,6 +69,7 @@
                                                           currency:@"XXX"];
         builder.accountId = payerAccount.id;
         builder.redeemerAlias = payee.firstAlias;
+        builder.toAlias = payee.firstAlias;
         builder.destinations = destinations;
         
         @try {
@@ -85,6 +87,7 @@
                                                           currency:@"USD"];
         builder.accountId = payerAccount.id;
         builder.redeemerAlias = payee.firstAlias;
+        builder.toAlias = payee.firstAlias;
         Token *token = [builder execute];
         Token *lookedUp = [payer getToken:token.id_p];
         XCTAssertEqualObjects(token, lookedUp);
@@ -97,18 +100,21 @@
                                                           currency:@"USD"];
         builder.accountId = payerAccount.id;
         builder.redeemerAlias = payee.firstAlias;
+        builder.toAlias = payee.firstAlias;
         [builder execute];
         
         TransferTokenBuilder *builder2 = [payer createTransferToken:100.22
                                                           currency:@"USD"];
         builder2.accountId = payerAccount.id;
         builder2.redeemerAlias = payee.firstAlias;
+        builder.toAlias = payee.firstAlias;
         [builder2 execute];
         
         TransferTokenBuilder *builder3 = [payer createTransferToken:100.33
                                                           currency:@"USD"];
         builder3.accountId = payerAccount.id;
         builder3.redeemerAlias = payee.firstAlias;
+        builder.toAlias = payee.firstAlias;
         [builder3 execute];
         
         PagedArray<Token *> *lookedUp = [payer getTransferTokensOffset:NULL limit:100];
@@ -123,6 +129,7 @@
                                                           currency:@"USD"];
         builder.accountId = payerAccount.id;
         builder.redeemerAlias = payee.firstAlias;
+        builder.toAlias = payee.firstAlias;
         Token *token = [builder execute];
         
         TokenOperationResult *endorsedResult = [payer endorseToken:token withKey:Key_Level_Standard];
@@ -146,6 +153,7 @@
                                                           currency:@"USD"];
         builder.accountId = payerAccount.id;
         builder.redeemerAlias = payee.firstAlias;
+        builder.toAlias = payee.firstAlias;
         builder.descr = descr;
         Token *token = [builder execute];
 
@@ -167,6 +175,7 @@
                                                           currency:@"USD"];
         builder.accountId = payerAccount.id;
         builder.redeemerAlias = payee.firstAlias;
+        builder.toAlias = payee.firstAlias;
         Token *token = [builder execute];
         
         TokenOperationResult *cancelledResult = [payer cancelToken:token];


### PR DESCRIPTION
Transfer tokens now MUST have the 'to' field set, due to changes with notifications where if the field is not set, an error is now thrown.