### PR TITLE
readme changes for non-token developers:

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,23 +9,18 @@ https://developer.token.io/sdk/pbdoc/io_token_proto_gateway.html
 Client Usage
 ------------
 
-To use the SDK version compatible with Token's Sandbox testing
-environment (typical usage), use the published pod:
-
-```
-  pod 'TokenSdk', '~> 1.0.72'
-```
-
 The SDK can be added to a client directly from git.
+E.g., to use version 1.0.72:
 
 ```
-  pod 'TokenSdk',  :git => 'https://github.com/tokenio/sdk-objc',:submodules => true
+  pod 'TokenSdk',  :git => 'https://github.com/tokenio/sdk-objc', :submodules => true, :tag => 'v1.0.72'
 ```
 
-or referenced locally in a Podfile
+Or your Podfile can refer to a repo cloned on disk (but you must update the
+clone "by hand"):
 
 ```
-  pod 'TokenSdk', :path => '../..'
+  pod 'TokenSdk', :path => '../sdk-objc'
 ```
 
 Dependencies
@@ -38,11 +33,6 @@ git submodule init
 git submodule update
 pod --repo-update install
 ```
-
-Pick up new protos
-------------------
-
-For now the protos are just copied over from `../lib-proto`. The script fails if the directory is not found. To pick up new protos, run `./bin/update-protos`. After the script finished executing one needs to reload the updated workspace file (with XCode or IntelliJ AppCode).
 
 Run Tests
 ---------

--- a/README.md
+++ b/README.md
@@ -10,10 +10,25 @@ Client Usage
 ------------
 
 The SDK can be added to a client directly from git.
-E.g., to use version 1.0.72:
+To use the version compatible with Token's
+"sandbox" testing environment:
 
 ```
-  pod 'TokenSdk',  :git => 'https://github.com/tokenio/sdk-objc', :submodules => true, :tag => 'v1.0.72'
+  source 'https://github.com/tokenio/token-cocoa-pods.git'
+  pod 'TokenSdk'
+```
+
+To use a specific version, e.g., 1.0.72:
+
+```
+  source 'https://github.com/tokenio/token-cocoa-pods.git'
+  pod 'TokenSdk', '1.0.72'
+```
+
+or
+
+```
+  pod 'TokenSdk', :git => 'https://github.com/tokenio/sdk-objc', :submodules => true, :tag => 'v1.0.72'
 ```
 
 Or your Podfile can refer to a repo cloned on disk (but you must update the

--- a/README.md
+++ b/README.md
@@ -1,17 +1,37 @@
 Overview
 ========
 
-Token SDK for iOS. The SDK is built on top of protobuf gRPC API definition.
+Token SDK for iOS. Docs https://developer.token.io/sdk/
 
-Pick up new protos
-------------------
+The SDK is built on top of protobuf gRPC API definition,
+https://developer.token.io/sdk/pbdoc/io_token_proto_gateway.html
 
-For now the protos are just copied over from `../lib-proto`. The script fails if the directory is not found. To pick up new protos run `./bin/update-protos`. After the script finished executing one needs to reload the updated workspace file (with XCode or IntelliJ AppCode).
+Client Usage
+------------
+
+To use the SDK version compatible with Token's Sandbox testing
+environment (typical usage), use the published pod:
+
+```
+  pod 'TokenSdk', '~> 1.0.72'
+```
+
+The SDK can be added to a client directly from git.
+
+```
+  pod 'TokenSdk',  :git => 'https://github.com/tokenio/sdk-objc',:submodules => true
+```
+
+or referenced locally in a Podfile
+
+```
+  pod 'TokenSdk', :path => '../..'
+```
 
 Dependencies
 ------------
 
-Most of the dependcies are managed with CocoaPods. Some use git submodules. So to initialize everything properly run:
+Most of the dependencies are managed with CocoaPods. Some use git submodules. So to initialize everything properly run:
 
 ```
 git submodule init
@@ -19,14 +39,13 @@ git submodule update
 pod --repo-update install
 ```
 
+Pick up new protos
+------------------
+
+For now the protos are just copied over from `../lib-proto`. The script fails if the directory is not found. To pick up new protos, run `./bin/update-protos`. After the script finished executing one needs to reload the updated workspace file (with XCode or IntelliJ AppCode).
+
 Run Tests
 ---------
-
-Local environment:
-
-```
-./bin/run-tests
-```
 
 Development environment:
 
@@ -40,17 +59,11 @@ Staging environment:
 ./bin/run-tests-staging
 ```
 
-Client Usage
-------------
-
-The SDK can be added to a client directly from git.
+Local environment (Token-internal):
 
 ```
-  pod 'TokenSdk',  :git => 'https://github.com/tokenio/sdk-objc',:submodules => true
+./bin/run-tests
 ```
 
-or referenced locally in a Podfile
 
-```
-  pod 'TokenSdk', :path => '../..'
-```
+


### PR DESCRIPTION
re-order sections to mention things like how to
use the sdk sooner, things like how to update
proto files later.

early on, say to use pod 'TokenSdk', '~> 1.0.72'
which works with sandbox. Only after that mention
how to use scary new versions