### PR TITLE
typo fix "onSucess"

### DIFF
--- a/Samples/TKSwift/TKSwift/ViewController.swift
+++ b/Samples/TKSwift/TKSwift/ViewController.swift
@@ -54,7 +54,7 @@ class ViewController: UIViewController {
         print("tokenIOAsync is this \(tokenIOAsync)")
         
         tokenIOAsync?.createMember(nil,
-                  onSucess: { (member) -> Void in
+                  onSuccess: { (member) -> Void in
                     self.tkmember = member
                     self.memberId = member?.id
                     self.memberLabel.text = "Id: \(self.memberId)"
@@ -71,7 +71,7 @@ class ViewController: UIViewController {
     
     @IBAction func addUsername(_ sender : AnyObject) {
         tkmember?.addUsername(usernameTextfield.text,
-                          onSucess: { (member) -> Void in
+                          onSuccess: { (member) -> Void in
                             self.info(title:"Info",message:"Done")
            },
                           onError: { (error) -> Void in
@@ -82,7 +82,7 @@ class ViewController: UIViewController {
     
     @IBAction func removeUsername(_ sender : AnyObject) {
         tkmember?.removeUsername(usernameTextfield.text,
-                           onSucess: { () -> Void in
+                           onSuccess: { () -> Void in
                             self.info(title:"Info",message:"Done")
             },
                            onError: { (error) -> Void in

--- a/src/api/TokenIO.h
+++ b/src/api/TokenIO.h
@@ -67,6 +67,11 @@ globalRpcErrorCallback:(OnError)globalRpcErrorCallback;
  * @param alias member alias to use, must be unique
  */
 - (void)createMember:(Alias *)alias
+            onSuccess:(OnSuccessWithTKMember)onSuccess
+             onError:(OnError)onError;
+
+// invokes createMember:onSuccess:onError
+- (void)createMember:(Alias *)alias
             onSucess:(OnSuccessWithTKMember)onSuccess
              onError:(OnError)onError;
 
@@ -115,6 +120,11 @@ globalRpcErrorCallback:(OnError)globalRpcErrorCallback;
  *
  * @param memberId member id
  */
+- (void)loginMember:(NSString *)memberId
+           onSuccess:(OnSuccessWithTKMember)onSuccess
+            onError:(OnError)onError;
+
+// calls loginMember:onSuccess:onError
 - (void)loginMember:(NSString *)memberId
            onSucess:(OnSuccessWithTKMember)onSuccess
             onError:(OnError)onError;

--- a/src/api/TokenIO.h
+++ b/src/api/TokenIO.h
@@ -70,11 +70,6 @@ globalRpcErrorCallback:(OnError)globalRpcErrorCallback;
             onSuccess:(OnSuccessWithTKMember)onSuccess
              onError:(OnError)onError;
 
-// invokes createMember:onSuccess:onError
-- (void)createMember:(Alias *)alias
-            onSucess:(OnSuccessWithTKMember)onSuccess
-             onError:(OnError)onError;
-
 /**
  * Provisions a new device for an existing user. The call generates a set
  * of keys that are returned back. The keys need to be approved by an
@@ -122,11 +117,6 @@ globalRpcErrorCallback:(OnError)globalRpcErrorCallback;
  */
 - (void)loginMember:(NSString *)memberId
            onSuccess:(OnSuccessWithTKMember)onSuccess
-            onError:(OnError)onError;
-
-// calls loginMember:onSuccess:onError
-- (void)loginMember:(NSString *)memberId
-           onSucess:(OnSuccessWithTKMember)onSuccess
             onError:(OnError)onError;
 
 /**

--- a/src/api/TokenIO.m
+++ b/src/api/TokenIO.m
@@ -89,7 +89,7 @@ globalRpcErrorCallback:(OnError)globalRpcErrorCallback_ {
 }
 
 - (void)createMember:(Alias *)alias
-            onSucess:(OnSuccessWithTKMember)onSuccess
+            onSuccess:(OnSuccessWithTKMember)onSuccess
              onError:(OnError)onError {
     Alias *tokenAgent = [Alias message];
     tokenAgent.value = @"token.io";
@@ -115,6 +115,13 @@ globalRpcErrorCallback:(OnError)globalRpcErrorCallback_ {
          }
      }
      onError:onError];
+}
+
+// workaround for old typo "onSucess"
+- (void)createMember:(Alias *)alias
+            onSucess:(OnSuccessWithTKMember)onSuccess
+             onError:(OnError)onError {
+    [self createMember:alias onSuccess:onSuccess onError:onError];
 }
 
 - (void)provisionDevice:(Alias *)alias
@@ -169,7 +176,7 @@ globalRpcErrorCallback:(OnError)globalRpcErrorCallback_ {
 }
 
 - (void)loginMember:(NSString *)memberId
-           onSucess:(OnSuccessWithTKMember)onSuccess
+           onSuccess:(OnSuccessWithTKMember)onSuccess
             onError:(OnError)onError {
     [unauthenticatedClient getMember:memberId
                            onSuccess:^(Member *member) {
@@ -190,6 +197,13 @@ globalRpcErrorCallback:(OnError)globalRpcErrorCallback_ {
                                } onError:onError];
                            }
                              onError:onError];
+}
+
+// workaround for old typo "onSucess"
+- (void)loginMember:(NSString *)memberId
+           onSucess:(OnSuccessWithTKMember)onSuccess
+            onError:(OnError)onError {
+    [self loginMember:memberId onSuccess:onSuccess onError:onError];
 }
 
 - (void)notifyPaymentRequest:(TokenPayload *)token

--- a/src/api/TokenIO.m
+++ b/src/api/TokenIO.m
@@ -117,13 +117,6 @@ globalRpcErrorCallback:(OnError)globalRpcErrorCallback_ {
      onError:onError];
 }
 
-// workaround for old typo "onSucess"
-- (void)createMember:(Alias *)alias
-            onSucess:(OnSuccessWithTKMember)onSuccess
-             onError:(OnError)onError {
-    [self createMember:alias onSuccess:onSuccess onError:onError];
-}
-
 - (void)provisionDevice:(Alias *)alias
               onSuccess:(OnSuccessWithDeviceInfo)onSuccess
                 onError:(OnError)onError {
@@ -197,13 +190,6 @@ globalRpcErrorCallback:(OnError)globalRpcErrorCallback_ {
                                } onError:onError];
                            }
                              onError:onError];
-}
-
-// workaround for old typo "onSucess"
-- (void)loginMember:(NSString *)memberId
-           onSucess:(OnSuccessWithTKMember)onSuccess
-            onError:(OnError)onError {
-    [self loginMember:memberId onSuccess:onSuccess onError:onError];
 }
 
 - (void)notifyPaymentRequest:(TokenPayload *)token

--- a/src/api/TokenIOSync.m
+++ b/src/api/TokenIOSync.m
@@ -40,7 +40,7 @@
     TKRpcSyncCall<TKMemberSync *> *call = [TKRpcSyncCall create];
     return [call run:^{
         [self.async createMember:alias
-                        onSucess:^(TKMember *member) {
+                        onSuccess:^(TKMember *member) {
                             TKMemberSync* memberSync = [TKMemberSync member:member];
                             call.onSuccess(memberSync);
                         }
@@ -93,7 +93,7 @@
     TKRpcSyncCall<TKMemberSync *> *call = [TKRpcSyncCall create];
     return [call run:^{
         [self.async loginMember:memberId
-                       onSucess:^(TKMember *member) {
+                       onSuccess:^(TKMember *member) {
                            TKMemberSync* memberSync = [TKMemberSync member:member];
                            call.onSuccess(memberSync);
                        }


### PR DESCRIPTION
createMember, loginMember had parameter typo "onSucess"

with this change, each method has two signatures: one with typo remaining, one with typo fixed