### PR TITLE
Sl.version

### DIFF
--- a/bin/publish
+++ b/bin/publish
@@ -67,17 +67,24 @@ function get_part {
 
 function update_version {
     local plist="../src/Info.plist"
+    local util="../src/util/TKUtil.m"
+
     sed -i.bak -e "s/^def Pod::tokenSdkVer;.*/def Pod::tokenSdkVer; \"${2}\"; end/" ${spec}
     sed -i.bak -e "s/:tag =>.*/:tag => \"v${2}\",/" ${spec}
 
     sed -i.bak -e "s/<string>${1}<\/string>/<string>${2}<\/string>/" ${plist}
+
+    sed -i.bak -e "s/return @\"${1}\";/return @\"${2}\";/" ${util}
+
     rm -rf ${spec}.bak
     rm -rf ${plist}.bak
+    rm -rf ${util}.bak
 
     git add ${spec}
     git add ${plist}
+    git add ${util}
 
-    git commit -m "Updating sdk version from ${1} to ${2}" ${spec} ${plist}
+    git commit -m "Updating sdk version from ${1} to ${2}" ${spec} ${plist} ${util}
     git push origin master
 }
 

--- a/src/rpc/TKRpc.m
+++ b/src/rpc/TKRpc.m
@@ -91,8 +91,7 @@ NSString *const kTokenScheme = @"Token-Ed25519-SHA512";
 }
 
 - (void)_setSdkHeaders:(GRPCProtoCall *)call {
-    NSString * version = [[NSBundle bundleForClass:self.class]
-                          objectForInfoDictionaryKey: @"CFBundleShortVersionString"];
+    NSString * version = [TKUtil tokenSdkVersion];
     call.requestHeaders[@"token-sdk"] = @"objc";
     call.requestHeaders[@"token-sdk-version"] = version;
     call.requestHeaders[@"token-dev-key"] = developerKey;

--- a/src/util/TKUtil.h
+++ b/src/util/TKUtil.h
@@ -12,6 +12,13 @@
 @interface TKUtil : NSObject
 
 /**
+ * Returns the current Token SDK version.
+ *
+ * @return Token SDK version
+ */
++ (NSString *)tokenSdkVersion;
+
+/**
  * Generates a nonce, used by many of the SDK methods to ensure idempotency.
  *
  * @return a string nonce

--- a/src/util/TKUtil.m
+++ b/src/util/TKUtil.m
@@ -10,6 +10,10 @@
 
 @implementation TKUtil
 
++ (NSString *)tokenSdkVersion {
+    return @"1.0.74";
+}
+
 + (NSString *)nonce {
     return [NSUUID UUID].UUIDString;
 }


### PR DESCRIPTION
CFBundleShortVersionString is not a safe option to get version number. The malfunction happen while Objc project add TokenSDK as a pod.