### PR TITLE
test loop-pump: block on semaphore a while, do less busy-looping

### DIFF
--- a/tests/TKTestBase.m
+++ b/tests/TKTestBase.m
@@ -84,7 +84,7 @@
         }
 
         // Are we done yet?
-        if (dispatch_semaphore_wait(done, DISPATCH_TIME_NOW) == 0) {
+        if (dispatch_semaphore_wait(done, dispatch_time(DISPATCH_TIME_NOW, 100000000)) == 0) {
             break;
         }
     }


### PR DESCRIPTION
tl;dr: depending on how worried we are about busy-waiting in dev/stg/etc tests vs slowing down local "tmuxinator" tests, this change might be a good/bad idea

I was changing this code https://github.com/tokenio/sdk-objc/pull/31/files#diff-774d5439c3139ae1e74467b1b29556a4R236 to use semaphores instead of plain booleans. I hoped it would loop less with semaphores, but it stayed the same.

I think it's because when we "wait" the semaphore, we time out immediately; we don't actually block on semaphore for any time.

This change tells TestBase to block 0.1s waiting on the semaphore. 
This reduces the number of times through the loop. E.g., in one set of tests things went
63 -> 24
11 -> 4
54 -> 26
24 -> 9

You might wonder: why not set a realllly long timeout and let the semaphore tell us when to wake up? We don't signal the semaphore until we're done with the whole block. The block might invoke a few RPCs. If we set a 10s timeout, then we only "pump" the RPC thread once every 10 seconds. This slows us down a lot.

As it is, I suspect that this 0.1s timeout might slow down local "tmuxinator" tests, but shouldn't slow down "cloud" tests. I don't know how much we run local tests.