### PR TITLE
fix runloop problem in sync calls

### DIFF
--- a/src/rpc/TKRpcSyncCall.m
+++ b/src/rpc/TKRpcSyncCall.m
@@ -38,7 +38,9 @@
 
 - (id)run:(void(^)())block {
     block();
-    dispatch_semaphore_wait(isDone, DISPATCH_TIME_FOREVER);
+    while (dispatch_semaphore_wait(isDone, DISPATCH_TIME_NOW)) {
+        [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:1]];
+    }
 
     if (error) {
         @throw error;

--- a/tests/TKSetupSamples.m
+++ b/tests/TKSetupSamples.m
@@ -21,15 +21,13 @@
 @implementation TKSetupSamples
 
 - (void)testCreateSDKClient {
-    [self run: ^(TokenIOSync *tIO) {
-        TokenIOBuilder *builder = [TokenIOSync sandboxBuilder];
-        builder.developerKey = @"4qY7lqQw8NOl9gng0ZHgT4xdiDqxqoGVutuZwrUYQsI";
-        TokenIOSync *tokenIO = [builder buildSync];
-
-        // Use the SDK client.
-        TKMemberSync *member = [tokenIO createMember:[self generateEmailAlias]];
-        XCTAssertNotNil(member);
-    }];
+    TokenIOBuilder *builder = [TokenIOSync sandboxBuilder];
+    builder.developerKey = @"4qY7lqQw8NOl9gng0ZHgT4xdiDqxqoGVutuZwrUYQsI";
+    TokenIOSync *tokenIO = [builder buildSync];
+    
+    // Use the SDK client.
+    TKMemberSync *member = [tokenIO createMember:[self generateEmailAlias]];
+    XCTAssertNotNil(member);;
 }
 
 @end


### PR DESCRIPTION
for whom is interested in the sync call bug, the reason is the the main thread has been hung by the semaphore. In the meanwhile, the gprc calls are trying to back to main thread for OnSuccess calls.

To fix this, I add runloop check here to allow other main thread calls can "jump the queue" before semaphore is done.