### PR TITLE
port Member.createTestBankAccount to objc (again)

### DIFF
--- a/src/api/TKMember.h
+++ b/src/api/TKMember.h
@@ -13,6 +13,7 @@
 #import "Blob.pbobjc.h"
 #import "Address.pbobjc.h"
 #import "Member.pbobjc.h"
+#import "Money.pbobjc.h"
 #import "TransferTokenBuilder.h"
 
 
@@ -604,6 +605,18 @@
 - (void)getBankInfo:(NSString *)bankId
           onSuccess:(OnSuccessWithBankInfo)onSuccess
             onError:(OnError)onError;
+
+/**
+ * Creates a fake test bank account, returns BankAuthorization for linking.
+ * Only works in test environments, not in production.
+ *
+ * @param balance starting balance
+ * @param onSuccess invoked on success
+ * @param onError invoked on error
+ */
+- (void)createTestBankAccount:(Money *)balance
+                    onSuccess:(OnSuccessWithBankAuthorization)onSuccess
+                      onError:(OnError)onError;
 
 /**
  * Returns profile for the given member id.

--- a/src/api/TKMember.m
+++ b/src/api/TKMember.m
@@ -589,6 +589,14 @@
                 onError:onError];
 }
 
+- (void)createTestBankAccount:(Money *)balance
+                    onSuccess:(OnSuccessWithBankAuthorization)onSuccess
+                      onError:(OnError)onError {
+    [client createTestBankAccount:balance
+                        onSuccess:onSuccess
+                          onError:onError];
+}
+
 - (void)getProfile:(NSString *)ownerId
          onSuccess:(OnSuccessWithProfile)onSuccess
            onError:(OnError)onError {

--- a/src/api/TKMemberSync.h
+++ b/src/api/TKMemberSync.h
@@ -487,6 +487,14 @@
  */
 - (BankInfo *)getBankInfo:(NSString *)bankId;
 
+/**
+ * Creates a fake test bank account; returns BankAuthorization for linking.
+ * Only works in test environments, not in production.
+ *
+ * @param balance starting balance
+ * @return bank authorization
+ */
+- (BankAuthorization *)createTestBankAccount:(Money *)balance;
 
 /**
  * Returns profile for the given member id.

--- a/src/api/TKMemberSync.m
+++ b/src/api/TKMemberSync.m
@@ -548,6 +548,15 @@
 
 }
 
+- (BankAuthorization *)createTestBankAccount:(Money *)balance {
+    TKRpcSyncCall<BankAuthorization *> *call = [TKRpcSyncCall create];
+    return [call run:^{
+        [self.async createTestBankAccount:balance
+                                onSuccess:call.onSuccess
+                                  onError:call.onError];
+    }];
+}
+
 - (Profile *)getProfile:(NSString *)ownerId{
     TKRpcSyncCall<Profile *> *call = [TKRpcSyncCall create];
     return [call run:^{

--- a/src/api/TKTypedef.h
+++ b/src/api/TKTypedef.h
@@ -1,6 +1,7 @@
 @class Member;
 @class NSError;
 @class Account;
+@class BankAuthorization;
 @class Blob;
 @class Attachment;
 @class Money;
@@ -70,6 +71,7 @@ typedef void (^ _Nonnull OnSuccessWithNotifications)(PagedArray<Notification *> 
 
 typedef void (^ _Nonnull OnSuccessWithTokenOperationResult)(TokenOperationResult * _Nonnull);
 
+typedef void (^ _Nonnull OnSuccessWithBankAuthorization)(BankAuthorization * _Nonnull);
 typedef void (^ _Nonnull OnSuccessWithBanks)(NSArray<Bank *> * _Nonnull);
 typedef void (^ _Nonnull OnSuccessWithBankInfo)(BankInfo * _Nonnull);
 

--- a/src/rpc/TKClient.h
+++ b/src/rpc/TKClient.h
@@ -460,6 +460,14 @@
             onError:(OnError)onError;
 
 /**
+ * Creates a test fake bank account and returns a BankAuthorization to link.
+ * Only works in test environments; doesn't work in production.
+ */
+- (void)createTestBankAccount:(Money *)balance
+                    onSuccess:(OnSuccessWithBankAuthorization)onSuccess
+                      onError:(OnError)onError;
+
+/**
  * Returns profile of a given member id
  *
  * @param ownerId member id

--- a/src/rpc/TKClient.m
+++ b/src/rpc/TKClient.m
@@ -1114,6 +1114,30 @@
              onError:onError];
 }
 
+- (void)createTestBankAccount:(Money *)balance
+                    onSuccess:(OnSuccessWithBankAuthorization)onSuccess
+                      onError:(OnError)onError {
+    CreateTestBankAccountRequest *request = [CreateTestBankAccountRequest message];
+    request.balance = balance;
+    RpcLogStart(request);
+    
+    GRPCProtoCall *call = [gateway
+                           RPCToCreateTestBankAccountWithRequest:request
+                           handler:
+                           ^(CreateTestBankAccountResponse *response, NSError *error) {
+                               if (response) {
+                                   RpcLogCompleted(response);
+                                   onSuccess(response.bankAuthorization);
+                               } else {
+                                   [errorHandler handle:onError withError:error];
+                               }
+                           }];
+    
+    [self _startCall:call
+         withRequest:request
+             onError:onError];
+}
+
 - (void)getProfile:(NSString *)ownerId
          onSuccess:(OnSuccessWithProfile)onSuccess
            onError:(OnError)onError {

--- a/tests/TKAccountsTests.m
+++ b/tests/TKAccountsTests.m
@@ -5,6 +5,7 @@
 
 #import "Account.pbobjc.h"
 
+#import "HostAndPort.h"
 #import "TKAccountSync.h"
 #import "TKJson.h"
 #import "TKMemberSync.h"
@@ -52,6 +53,9 @@
                                                                    accountNumbers: [NSArray arrayWithObjects: checking.accountNumber, saving.accountNumber, nil]];
         [auth.accountsArray addObjectsFromArray:encAccounts];
         accounts = [member linkAccounts:auth];
+    }];
+    [self runUntilTrue:^{
+        return accounts != nil;
     }];
 }
 

--- a/tests/TKTestBase.h
+++ b/tests/TKTestBase.h
@@ -77,12 +77,10 @@ typedef id (^AsyncTestBlockWithResult)(TokenIOSync *);
 /**
  * Creates a new bank authorization for a member
  *
- * @param tokenIO an entry point for Token API
- * @param memberId member ID
+ * @param member member
  * @return a bank authorization
  */
-- (BankAuthorization *)createBankAuthorization:(TokenIOSync *)tokenIO
-                                      memberId:(NSString *)memberId;
+- (BankAuthorization *)createBankAuthorization:(TKMemberSync *)member;
 
 /**
  * Formats HostAndPort instance.

--- a/tests/TKTestBase.m
+++ b/tests/TKTestBase.m
@@ -4,13 +4,11 @@
 //
 
 #import "Money.pbobjc.h"
-#import "fank/Fank.pbobjc.h"
 
 #import "HostAndPort.h"
 #import "TKTestBase.h"
 #import "TokenIOSync.h"
 #import "TokenIOBuilder.h"
-#import "TKBankClient.h"
 #import "TKMemberSync.h"
 #import "TKAccountSync.h"
 #import "TKTestKeyStore.h"
@@ -27,11 +25,6 @@
     [super setUp];
     NSString *sslOverride = [[[NSProcessInfo processInfo] environment] objectForKey:@"TOKEN_USE_SSL"];
     useSsl = sslOverride ? [sslOverride boolValue] : NO;
-
-    HostAndPort *fank = [self hostAndPort:@"TOKEN_BANK" withDefaultPort:8100];
-    _bank = [TKBankClient bankClientWithHost:fank.host
-                                        port:fank.port
-                                      useSsl:useSsl];
 
     queue = dispatch_queue_create("io.token.Test", nil);
 }
@@ -134,57 +127,19 @@
 
 - (TKAccountSync *)createAccount:(TokenIOSync *)token {
     TKMemberSync *member = [self createMember:token];
-
-    NSString *firstName = @"Test";
-    NSString *lastName = @"Testoff";
-    NSString *bankId = @"iron";
-    NSString *accountName = @"Checking";
-    NSString *bankAccountNumber = [@"iban:" stringByAppendingString:[TKUtil nonce]];
     
-    FankClient *fankClient = [_bank addClientWithFirstName:firstName lastName:lastName];
-    [_bank addAccountWithName:accountName
-                    forClient:fankClient
-            withAccountNumber:bankAccountNumber
-                       amount:@"1000000.00"
-                     currency:@"USD"];
-    
-    NSString *clientId = fankClient.id_p;
-    NSArray<SealedMessage*> *encAccounts = [_bank authorizeAccountLinkingFor:member.id
-                                                                 clientId:clientId
-                                                           accountNumbers:@[bankAccountNumber]];
-    BankAuthorization * auth = [BankAuthorization message];
-    auth.bankId = bankId;
-    [auth.accountsArray addObjectsFromArray:encAccounts];
+    BankAuthorization * auth = [self createBankAuthorization:member];
 
     NSArray<TKAccountSync *> *accounts = [member linkAccounts:auth];
     XCTAssert(accounts.count == 1);
     return accounts[0];
 }
 
-- (BankAuthorization *)createBankAuthorization:(TokenIOSync *)token
-                              memberId:(NSString *)memberId {
-    NSString *firstName = @"Test";
-    NSString *lastName = @"Testoff";
-    NSString *bankId = @"iron";
-    NSString *accountName = @"Checking";
-    NSString *bankAccountNumber = [@"iban:" stringByAppendingString:[TKUtil nonce]];
-    
-    FankClient *fankClient = [_bank addClientWithFirstName:firstName lastName:lastName];
-    [_bank addAccountWithName:accountName
-                    forClient:fankClient
-            withAccountNumber:bankAccountNumber
-                       amount:@"1000000.00"
-                     currency:@"USD"];
-    
-    NSString *clientId = fankClient.id_p;
-    NSArray<SealedMessage*> *encAccounts = [_bank authorizeAccountLinkingFor:memberId
-                                                                 clientId:clientId
-                                                           accountNumbers:@[bankAccountNumber]];
-    BankAuthorization * auth = [BankAuthorization message];
-    auth.bankId = bankId;
-    [auth.accountsArray addObjectsFromArray:encAccounts];
-
-    return auth;
+- (BankAuthorization *)createBankAuthorization:(TKMemberSync *)member {
+    Money *balance = [Money message];
+    balance.value = @"1000000.00";
+    balance.currency = @"USD";
+    return [member createTestBankAccount:balance];
 }
 
 - (HostAndPort *)hostAndPort:(NSString *)var withDefaultPort:(int)port {

--- a/tests/TKTestBase.m
+++ b/tests/TKTestBase.m
@@ -5,8 +5,9 @@
 
 #import "Money.pbobjc.h"
 
-#import "HostAndPort.h"
 #import "TKTestBase.h"
+#import "HostAndPort.h"
+#import "TKBankClient.h"
 #import "TokenIOSync.h"
 #import "TokenIOBuilder.h"
 #import "TKMemberSync.h"
@@ -25,6 +26,11 @@
     [super setUp];
     NSString *sslOverride = [[[NSProcessInfo processInfo] environment] objectForKey:@"TOKEN_USE_SSL"];
     useSsl = sslOverride ? [sslOverride boolValue] : NO;
+
+    HostAndPort *fank = [self hostAndPort:@"TOKEN_BANK" withDefaultPort:8100];
+    _bank = [TKBankClient bankClientWithHost:fank.host
+                                        port:fank.port
+                                      useSsl:useSsl];
 
     queue = dispatch_queue_create("io.token.Test", nil);
 }

--- a/tests/TKTransferTokenRedemptionTests.m
+++ b/tests/TKTransferTokenRedemptionTests.m
@@ -67,7 +67,7 @@
     [self run: ^(TokenIOSync *tokenIO) {
         TransferTokenBuilder *builder = [payer createTransferToken:100.11
                                                           currency:@"USD"];
-        builder.bankAuthorization = [self createBankAuthorization:tokenIO memberId:payer.id];
+        builder.bankAuthorization = [self createBankAuthorization:payer];
         builder.redeemerAlias = payer.firstAlias;
         Token *token = [builder execute];
         TokenOperationResult *endorsedResult = [payer endorseToken:token withKey:Key_Level_Standard];


### PR DESCRIPTION
This is similar to https://github.com/tokenio/sdk-objc/pull/37 , which had a bug + I reverted.

This change, unlike that change, doesn't remove _bank from TKTestBase, which I learned is the variable behind the property "bank". 