### PR TITLE
fix flaky test

### DIFF
--- a/sample/TKAccessSamples.m
+++ b/sample/TKAccessSamples.m
@@ -111,7 +111,7 @@
     // find token done snippet to include in docs
     
     [self runUntilTrue:^ {
-        return (foundToken != nil) && [foundToken isEqual:accessToken];
+        return (foundToken != nil) && [foundToken.id_p isEqual:accessToken.id_p];
     }];
     
     // replaceAndEndorseAccessToken begin snippet to include in docs
@@ -216,7 +216,7 @@
                          }];
 
     [self runUntilTrue:^ {
-        return (foundToken != nil) && [foundToken isEqual:accessToken];
+        return (foundToken != nil) && [foundToken.id_p isEqual:accessToken.id_p];
     }];
 
     // replaceNoEndorse begin snippet to include in docs
@@ -237,7 +237,7 @@
     // replaceNoEndorse done snippet to include in docs
 
     [self runUntilTrue:^ {
-        return (![accessToken isEqual:foundToken]);
+        return (![accessToken.id_p isEqual:foundToken.id_p]);
     }];
 }
 


### PR DESCRIPTION
one of these tests failed once: it endorsed a token, then "found"
that token again with getAccessTokens; it compared these two copies
of the token by equality. This mostly passed, but it failed just now:
the two token protos had a couple of signatures in a different order.
Semantically, these tokens are "the same", but proto isEqual: check
didn't like it.

So change that test to check for equal .id_p instead of the whole structure.
And change some other checks, too. Just because they've been passing
so far doesn't mean they won't go flaky later.