### PR TITLE
AccessTokenConfig.* : make jazzy doc look less weird

### DIFF
--- a/src/api/AccessTokenConfig.h
+++ b/src/api/AccessTokenConfig.h
@@ -11,10 +11,7 @@
 /**
  * Helps building an access token payload.
  */
-@interface AccessTokenConfig : NSObject {
-    TokenPayload * payload;
-    NSMutableSet<AccessBody_Resource *> * resources;
-}
+@interface AccessTokenConfig : NSObject 
 
 /**
  * Creates a new instance with a provided redeemer alias (the 'payload.to' field).

--- a/src/api/AccessTokenConfig.m
+++ b/src/api/AccessTokenConfig.m
@@ -7,7 +7,10 @@
 
 #import "AccessTokenConfig.h"
 
-@implementation AccessTokenConfig
+@implementation AccessTokenConfig {
+    TokenPayload * payload;
+    NSMutableSet<AccessBody_Resource *> * resources;
+}
 
 + (AccessTokenConfig *)create:(Alias *)redeemerAlias {
     return [[AccessTokenConfig alloc] initWithRedeemer:redeemerAlias];


### PR DESCRIPTION
https://developer.token.io/sdk/objcdoc/Classes/AccessTokenConfig.html looks unusual. before it shows the usual web-like docs, there's a section that shows lots of comments

```
/**
 * Creates a new instance with a provided redeemer alias (the 'payload.to' field).
 *
 * @param redeemerAlias alias of the token redeemer
 */
```

When I looked at the header file, I noticed something unusual: the instance variables were in the header file; we usually put them in the `.m` file. I tried moving them to the the `.m` file and the docs looked more like usual. And the tests still pass. 