### PR TITLE
comments for "jazzy" tool

### DIFF
--- a/src/api/PagedArray.h
+++ b/src/api/PagedArray.h
@@ -22,7 +22,7 @@
 - (id)initWith:(NSArray<T> *)items
         offset:(NSString *)offset;
 
-/// Returned list of items
+/// List of items in this "page".
 @property (readonly, retain) NSArray<T> *items;
 
 /// Offset string. Pass this as offset (instead of NULL) to fetch next "page" of items.

--- a/src/api/PagedArray.h
+++ b/src/api/PagedArray.h
@@ -22,7 +22,10 @@
 - (id)initWith:(NSArray<T> *)items
         offset:(NSString *)offset;
 
+/// Returned list of items
 @property (readonly, retain) NSArray<T> *items;
+
+/// Offset string. Pass this as offset (instead of NULL) to fetch next "page" of items.
 @property (readonly, retain) NSString *offset;
 
 @end

--- a/src/api/TKAccount.h
+++ b/src/api/TKAccount.h
@@ -28,13 +28,13 @@
 /// Id by which Token system identifies this account.
 @property (atomic, readonly) NSString *id;
 
-/// Human readable name, for example "Checking account with number ending -2718"
+/// Human-readable name. For example, could be "Checking account with number ending -2718".
 @property (atomic, readonly) NSString *name;
 
-/// Id by which Token system identifies this account's bank
+/// Id by which Token system identifies this account's bank.
 @property (atomic, readonly) NSString *bankId;
 
-/// Does account require re-linking?
+/// Flag indicating whether account needs re-linking.
 @property (atomic, readonly) BOOL isLocked;
 
 + (TKAccount *)account:(Account *)account

--- a/src/api/TKAccount.h
+++ b/src/api/TKAccount.h
@@ -22,10 +22,29 @@
  */
 @interface TKAccount : NSObject
 
+/**
+ * Owner member.
+ */
 @property (atomic, readonly) TKMemberSync *member;
+
+/**
+ * Id by which Token system identifies this account.
+ */
 @property (atomic, readonly) NSString *id;
+
+/**
+ * Human readable name, such as "Checking account with number ending -2718"
+ */
 @property (atomic, readonly) NSString *name;
+
+/**
+ * Id by which Token system identifies this account's bank
+ */
 @property (atomic, readonly) NSString *bankId;
+
+/**
+ * Does account require re-linking?
+ */
 @property (atomic, readonly) BOOL isLocked;
 
 + (TKAccount *)account:(Account *)account

--- a/src/api/TKAccount.h
+++ b/src/api/TKAccount.h
@@ -22,29 +22,19 @@
  */
 @interface TKAccount : NSObject
 
-/**
- * Owner member.
- */
+/// Owner member.
 @property (atomic, readonly) TKMemberSync *member;
 
-/**
- * Id by which Token system identifies this account.
- */
+/// Id by which Token system identifies this account.
 @property (atomic, readonly) NSString *id;
 
-/**
- * Human readable name, such as "Checking account with number ending -2718"
- */
+/// Human readable name, for example "Checking account with number ending -2718"
 @property (atomic, readonly) NSString *name;
 
-/**
- * Id by which Token system identifies this account's bank
- */
+/// Id by which Token system identifies this account's bank
 @property (atomic, readonly) NSString *bankId;
 
-/**
- * Does account require re-linking?
- */
+/// Does account require re-linking?
 @property (atomic, readonly) BOOL isLocked;
 
 + (TKAccount *)account:(Account *)account

--- a/src/api/TKAccountSync.h
+++ b/src/api/TKAccountSync.h
@@ -23,29 +23,19 @@
  */
 @interface TKAccountSync : NSObject
 
-/**
- * Asynchronous version.
- */
+/// Asynchronous version.
 @property (atomic, readonly) TKAccount *async;
 
-/**
- * Owner member.
- */
+/// Owner member.
 @property (atomic, readonly) TKMemberSync *member;
 
-/**
- * Id by which Token system identifies this account.
- */
+/// Id by which Token system identifies this account.
 @property (atomic, readonly) NSString *id;
 
-/**
- * Human readable name, such as "Checking account with number ending -2718"
- */
+/// Human readable name, such as "Checking account with number ending -2718"
 @property (atomic, readonly) NSString *name;
 
-/**
- * Id by which Token system identifies this account's bank
- */ 
+/// Id by which Token system identifies this account's bank
 @property (atomic, readonly) NSString *bankId;
 
 + (TKAccountSync *)account:(TKAccount *)delegate;

--- a/src/api/TKAccountSync.h
+++ b/src/api/TKAccountSync.h
@@ -23,10 +23,29 @@
  */
 @interface TKAccountSync : NSObject
 
+/**
+ * Asynchronous version.
+ */
 @property (atomic, readonly) TKAccount *async;
+
+/**
+ * Owner member.
+ */
 @property (atomic, readonly) TKMemberSync *member;
+
+/**
+ * Id by which Token system identifies this account.
+ */
 @property (atomic, readonly) NSString *id;
+
+/**
+ * Human readable name, such as "Checking account with number ending -2718"
+ */
 @property (atomic, readonly) NSString *name;
+
+/**
+ * Id by which Token system identifies this account's bank
+ */ 
 @property (atomic, readonly) NSString *bankId;
 
 + (TKAccountSync *)account:(TKAccount *)delegate;

--- a/src/api/TKAccountSync.h
+++ b/src/api/TKAccountSync.h
@@ -32,10 +32,10 @@
 /// Id by which Token system identifies this account.
 @property (atomic, readonly) NSString *id;
 
-/// Human readable name, such as "Checking account with number ending -2718"
+/// Human-readable name. For example, "Checking account with number ending -2718".
 @property (atomic, readonly) NSString *name;
 
-/// Id by which Token system identifies this account's bank
+/// Id by which Token system identifies this account's bank.
 @property (atomic, readonly) NSString *bankId;
 
 + (TKAccountSync *)account:(TKAccount *)delegate;

--- a/src/api/TKBalance.h
+++ b/src/api/TKBalance.h
@@ -16,10 +16,10 @@
  */
 @interface TKBalance : NSObject
 
-/// Current balance
+/// Current balance.
 @property Money *current;
 
-/// Available balance
+/// Available balance.
 @property Money *available;
 
 @end

--- a/src/api/TKBalance.h
+++ b/src/api/TKBalance.h
@@ -16,7 +16,10 @@
  */
 @interface TKBalance : NSObject
 
+/// Current balance
 @property Money *current;
+
+/// Available balance
 @property Money *available;
 
 @end

--- a/src/api/TKMember.h
+++ b/src/api/TKMember.h
@@ -33,16 +33,16 @@
  */
 @interface TKMember : NSObject
 
-/// Member ID
+/// Member ID.
 @property (readonly, retain) NSString *id;
 
-/// Convenience to aliases[0]
+/// Convenience access to aliases[0].
 @property (readonly, retain) Alias *firstAlias;
 
 /// Member's aliases: emails, etc. In UI, user normally refers to member by alias.
 @property (readonly, retain) NSArray<Alias *> *aliases;
 
-/// Crypto keys
+/// Crypto keys.
 @property (readonly, retain) NSArray<Key *> *keys;
 
 /**

--- a/src/api/TKMember.h
+++ b/src/api/TKMember.h
@@ -33,9 +33,16 @@
  */
 @interface TKMember : NSObject
 
+/// Member ID
 @property (readonly, retain) NSString *id;
+
+/// Convenience to aliases[0]
 @property (readonly, retain) Alias *firstAlias;
+
+/// Member's aliases: emails, etc. In UI, user normally refers to member by alias.
 @property (readonly, retain) NSArray<Alias *> *aliases;
+
+/// Crypto keys
 @property (readonly, retain) NSArray<Key *> *keys;
 
 /**

--- a/src/api/TKMemberSync.h
+++ b/src/api/TKMemberSync.h
@@ -39,10 +39,19 @@
  */
 @interface TKMemberSync : NSObject
 
+/// Asynchronous API to member.
 @property (readonly, retain) TKMember *async;
+
+/// Member ID
 @property (readonly, retain) NSString *id;
+
+/// Convenience to aliases[0]
 @property (readonly, retain) Alias *firstAlias;
+
+/// Member's aliases: emails, etc. In UI, user normally refers to member by alias.
 @property (readonly, retain) NSArray<Alias *> *aliases;
+
+/// Crypto keys
 @property (readonly, retain) NSArray<Key *> *keys;
 
 /**

--- a/src/api/TKMemberSync.h
+++ b/src/api/TKMemberSync.h
@@ -42,16 +42,16 @@
 /// Asynchronous API to member.
 @property (readonly, retain) TKMember *async;
 
-/// Member ID
+/// Member ID.
 @property (readonly, retain) NSString *id;
 
-/// Convenience to aliases[0]
+/// Convenience access to aliases[0].
 @property (readonly, retain) Alias *firstAlias;
 
 /// Member's aliases: emails, etc. In UI, user normally refers to member by alias.
 @property (readonly, retain) NSArray<Alias *> *aliases;
 
-/// Crypto keys
+/// Crypto keys.
 @property (readonly, retain) NSArray<Key *> *keys;
 
 /**

--- a/src/api/TokenIOBuilder.h
+++ b/src/api/TokenIOBuilder.h
@@ -18,13 +18,13 @@
  */
 @interface TokenIOBuilder : NSObject
 
-/// Host address. For example, "api-grpc.sandbox.token.io"
+/// Host address. For example, "api-grpc.sandbox.token.io".
 @property (readwrite, copy) NSString *host;
 
-/// Host port
+/// Host port.
 @property (readwrite) int port;
 
-/// Request timeout duration
+/// Request timeout duration used with RPC requests.
 @property (readwrite) int timeoutMs;
 
 /// Key that "tags" requests with ID of developer organization. Ask Token for a developer key you can use.
@@ -33,7 +33,7 @@
 /// Use SSL to protect connection?
 @property (readwrite) BOOL useSsl;
 
-/// Crypto key storage
+/// Crypto key storage. By default, uses Secure Enclave.
 @property (readwrite) id<TKKeyStore> keyStore;
 /**
  * Optional callback to invoke when a cross-cutting RPC error is raised (for example: kTKErrorSdkVersionMismatch).

--- a/src/api/TokenIOBuilder.h
+++ b/src/api/TokenIOBuilder.h
@@ -18,12 +18,22 @@
  */
 @interface TokenIOBuilder : NSObject
 
+/// Host address. For example, "api-grpc.sandbox.token.io"
 @property (readwrite, copy) NSString *host;
+
+/// Host port
 @property (readwrite) int port;
+
+/// Request timeout duration
 @property (readwrite) int timeoutMs;
-/* Ask Token for a developerKey you can use. */
+
+/// Key that "tags" requests with ID of developer organization. Ask Token for a developer key you can use.
 @property (readwrite, copy) NSString *developerKey;
+
+/// Use SSL to protect connection?
 @property (readwrite) BOOL useSsl;
+
+/// Crypto key storage
 @property (readwrite) id<TKKeyStore> keyStore;
 /**
  * Optional callback to invoke when a cross-cutting RPC error is raised (for example: kTKErrorSdkVersionMismatch).

--- a/src/api/TokenIOSync.h
+++ b/src/api/TokenIOSync.h
@@ -25,6 +25,7 @@
  */
 @interface TokenIOSync : NSObject
 
+/// Asynchronous API.
 @property (readonly, retain) TokenIO *async;
 
 /**

--- a/src/api/TransferTokenBuilder.h
+++ b/src/api/TransferTokenBuilder.h
@@ -16,24 +16,16 @@
  */
 @interface TransferTokenBuilder : NSObject
 
-/**
- * Member, set by `create`.
- */
+/// Member, normally set by `create`.
 @property (readwrite) TKMember *member;
 
-/**
- * Specify member ID of payer account.
- */
+/// Specify member ID of payer account.
 @property (readwrite) NSString *fromMemberId;
 
-/**
- * Currency string, normally set by `create`.
- */
+/// Currency string, normally set by `create`.
 @property (readwrite) NSString *currency;
 
-/**
- * Transfer amount, normally set by `create`.
- */
+/// Transfer amount, normally set by `create`.
 @property (readwrite) double lifetimeAmount;
 
 /**
@@ -43,75 +35,49 @@
  */
 @property (readwrite) double chargeAmount;
 
-/**
- * Account ID from which to pay.
- */
+/// Account ID from which to pay.
 @property (readwrite) NSString *accountId;
+
+/// Bank authorization for payment (useful if not paying from linked account)
 @property (readwrite) BankAuthorization *bankAuthorization;
 
-/**
- * Expiration time in ms since 1970.
- */
+/// Expiration time in ms since 1970.
 @property (readwrite) int64_t expiresAtMs;
-/**
- * Effective-at time in ms since 1970.
- */
+
+/// Effective-at time in ms since 1970.
 @property (readwrite) int64_t effectiveAtMs;
 
-/**
- * Specify redeemer by alias.
- */
+/// Specify redeemer by alias.
 @property (readwrite) Alias *redeemerAlias;
 
-/**
- * Specify redeemer by Member ID.
- */
+/// Specify redeemer by Member ID.
 @property (readwrite) NSString* redeemerMemberId;
 
-/**
- * Specify payer by Alias.
- */
+/// Specify payer by Alias.
 @property (readwrite) Alias *fromAlias;
 
-/**
- * Specify payee by Alias.
- */
-
+/// Specify payee by Alias.
 @property (readwrite) Alias *toAlias;
 
-/**
- * Specify payee by Member ID.
- */
+/// Specify payee by Member ID.
 @property (readwrite) NSString *toMemberId;
 
-/**
- * Specify description
- */
+/// Specify description
 @property (readwrite) NSString *descr;
 
-/**
- * Fees, FX
- */
+/// Fees, FX
 @property (readwrite) Pricing *pricing;
 
-/**
- * Specify purpose of payment.
- */
+/// Specify purpose of payment.
 @property (readwrite) PurposeOfPayment purposeOfPayment;
 
-/**
- * Specify destination bank accounts.
- */
+/// Specify destination bank accounts.
 @property (readwrite) NSArray<TransferEndpoint*> *destinations;
 
-/**
- * Attach "files"
- */
+/// Attach "files"
 @property (readwrite) NSArray<Attachment*> *attachments;
 
-/**
- * Specify reference ID. If not set, the Token system chooses a random one.
- */
+/// Specify reference ID. If not set, the Token system chooses a random one.
 @property (readwrite) NSString *refId;
 
 /**

--- a/src/api/TransferTokenBuilder.h
+++ b/src/api/TransferTokenBuilder.h
@@ -11,27 +11,107 @@
 @class TransferEndpoint;
 @class Alias;
 
+/**
+ * Helper class that builds Transfer Tokens.
+ */
 @interface TransferTokenBuilder : NSObject
 
+/**
+ * Member, set by `create`.
+ */
 @property (readwrite) TKMember *member;
+
+/**
+ * Specify member ID of payer account.
+ */
 @property (readwrite) NSString *fromMemberId;
+
+/**
+ * Currency string, normally set by `create`.
+ */
 @property (readwrite) NSString *currency;
+
+/**
+ * Transfer amount, normally set by `create`.
+ */
 @property (readwrite) double lifetimeAmount;
+
+/**
+ * Specify how much redeemer can redeem each time.
+ * For example, to enable 12x 10€ payments, set lifetimeAmount to 120,
+ * chargeAmount to 10.
+ */
 @property (readwrite) double chargeAmount;
+
+/**
+ * Account ID from which to pay.
+ */
 @property (readwrite) NSString *accountId;
 @property (readwrite) BankAuthorization *bankAuthorization;
+
+/**
+ * Expiration time in ms since 1970.
+ */
 @property (readwrite) int64_t expiresAtMs;
+/**
+ * Effective-at time in ms since 1970.
+ */
 @property (readwrite) int64_t effectiveAtMs;
+
+/**
+ * Specify redeemer by alias.
+ */
 @property (readwrite) Alias *redeemerAlias;
+
+/**
+ * Specify redeemer by Member ID.
+ */
 @property (readwrite) NSString* redeemerMemberId;
+
+/**
+ * Specify payer by Alias.
+ */
 @property (readwrite) Alias *fromAlias;
+
+/**
+ * Specify payee by Alias.
+ */
+
 @property (readwrite) Alias *toAlias;
+
+/**
+ * Specify payee by Member ID.
+ */
 @property (readwrite) NSString *toMemberId;
+
+/**
+ * Specify description
+ */
 @property (readwrite) NSString *descr;
+
+/**
+ * Fees, FX
+ */
 @property (readwrite) Pricing *pricing;
+
+/**
+ * Specify purpose of payment.
+ */
 @property (readwrite) PurposeOfPayment purposeOfPayment;
+
+/**
+ * Specify destination bank accounts.
+ */
 @property (readwrite) NSArray<TransferEndpoint*> *destinations;
+
+/**
+ * Attach "files"
+ */
 @property (readwrite) NSArray<Attachment*> *attachments;
+
+/**
+ * Specify reference ID. If not set, the Token system chooses a random one.
+ */
 @property (readwrite) NSString *refId;
 
 /**

--- a/src/api/TransferTokenBuilder.h
+++ b/src/api/TransferTokenBuilder.h
@@ -37,7 +37,7 @@
 /// Account ID from which to pay.
 @property (readwrite) NSString *accountId;
 
-/// Bank authorization for payment (useful if not paying from linked account)
+/// Bank authorization for payment. This is useful if not paying from linked account.
 @property (readwrite) BankAuthorization *bankAuthorization;
 
 /// Expiration time in ms since 1970.
@@ -46,34 +46,34 @@
 /// Effective-at time in ms since 1970.
 @property (readwrite) int64_t effectiveAtMs;
 
-/// Specify redeemer by alias.
+/// Redeemer, specified by alias.
 @property (readwrite) Alias *redeemerAlias;
 
-/// Specify redeemer by Member ID.
+/// Redeemer, specified by Member ID.
 @property (readwrite) NSString* redeemerMemberId;
 
-/// Specify payer by Alias.
+/// Ppayer, specified by Alias.
 @property (readwrite) Alias *fromAlias;
 
-/// Specify payee by Alias.
+/// Payee, specified by Alias.
 @property (readwrite) Alias *toAlias;
 
-/// Specify payee by Member ID.
+/// Payee, specified by Member ID.
 @property (readwrite) NSString *toMemberId;
 
-/// Specify description
+/// Description.
 @property (readwrite) NSString *descr;
 
-/// Fees, FX
+/// Fees, FX.
 @property (readwrite) Pricing *pricing;
 
-/// Specify purpose of payment.
+/// Purpose of payment.
 @property (readwrite) PurposeOfPayment purposeOfPayment;
 
-/// Specify destination bank accounts.
+/// Destination bank accounts.
 @property (readwrite) NSArray<TransferEndpoint*> *destinations;
 
-/// Attach "files"
+/// Attachment "files".
 @property (readwrite) NSArray<Attachment*> *attachments;
 
 /// Specify reference ID. If not set, the Token system chooses a random one.


### PR DESCRIPTION
Jazzy generates our web docs. When it sees a comment-less property, it just says "undocumented"; it doesn't say the type of the property, which would be pretty useful. Grr.

So add comments for properties of things in src/api. You wouldn't think a comment like "Member's ID" for a TKMember property named `id` would be useful, but Jazzy likes them.