### PR TITLE
Fix getAccessToken sample

### DIFF
--- a/sample/TKAccessSamples.m
+++ b/sample/TKAccessSamples.m
@@ -83,28 +83,20 @@
     
     __block Token *foundToken = nil;
     
-    // find token begin snippet to include in docs
-    [grantor getAccessTokensOffset:NULL
-                             limit:100
-                         onSuccess:^(PagedArray<Token *> *ary) {
-                             for (Token *at in ary.items) {
-                                 if ([at.payload.to.alias isEqual:granteeAlias]) {
-                                     foundToken = at;
-                                     break;
-                                 }
-                             }
-                         } onError:^(NSError* e) {
-                               // something went wrong
-                               @throw [NSException exceptionWithName:@"GetAccessTokensException"
-                                                              reason:[e localizedFailureReason]
-                                                            userInfo:[e userInfo]];
-                           }];
-    // find token done snippet to include in docs
-    
     [self runUntilTrue:^ {
-        return (foundToken != nil) && [foundToken.id_p isEqual:accessToken.id_p];
-    }];
+        // find token begin snippet to include in docs
+        PagedArray<Token *> *ary = [self.payerSync getAccessTokensOffset:NULL limit:100];
+        for (Token *at in ary.items) {
+            if ([at.payload.to.alias isEqual:granteeAlias]) {
+                foundToken = at;
+                break;
+            }
+        }
+        // find token done snippet to include in docs
     
+        return (foundToken != nil) && [foundToken.id_p isEqual:accessToken.id_p];
+    } backOffTimeMs:1000];
+
     // replaceAndEndorseAccessToken begin snippet to include in docs
     AccessTokenConfig *newAccess = [AccessTokenConfig fromPayload:foundToken.payload];
     [newAccess forAllBalances];

--- a/sample/TKSampleBase.h
+++ b/sample/TKSampleBase.h
@@ -36,6 +36,16 @@
  * after the sample code, runUntilTrue to assert side effect happens.
  *
  * @param condition block that returns a Boolean
+ * @param backOffTimeMs how long to wait between invocations of `condition`
+ */
+- (void)runUntilTrue:(int (^)(void))condition backOffTimeMs:(int)backOffTimeMs;
+
+/**
+ * Invokes grpc-using block. Runs until `condition` block returns true,
+ * hits exception, or times out. Does not sleep between invocations of
+ * `condition`.
+ *
+ * @param condition block that returns a Boolean
  */
 - (void)runUntilTrue:(int (^)(void))condition;
 

--- a/sample/TKSampleBase.m
+++ b/sample/TKSampleBase.m
@@ -33,6 +33,10 @@
 }
 
 - (void)runUntilTrue:(int (^)(void))condition {
+    [self runUntilTrue:condition backOffTimeMs:0];
+}
+
+- (void)runUntilTrue:(int (^)(void))condition backOffTimeMs:(int)backOffTimeMs {
     NSTimeInterval start = [[NSDate date] timeIntervalSince1970];
     while(true) {
         if (condition()) {
@@ -40,6 +44,7 @@
         }
         NSTimeInterval now = [[NSDate date] timeIntervalSince1970];
         if (now - start < 20) {
+            usleep(1000 * backOffTimeMs);
             [[NSRunLoop mainRunLoop] runMode:NSDefaultRunLoopMode
                                   beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
         } else {


### PR DESCRIPTION
Data backing getAccessTokens is update asynchronously so we need to poll.
Use the sync api to avoid concurrency issues while polling.