### PR TITLE
web docs: see header files in dirs other than src/api/

### DIFF
--- a/bin/gen-doc
+++ b/bin/gen-doc
@@ -10,6 +10,8 @@ jazzy \
   --author_url https://developer.token.io \
   --github_url https://github.com/tokenio/sdk-objc \
   --umbrella-header 'src/api/TokenSdk.h' \
+  --framework-root 'src' \
+  --exclude 'src/generated/*' \
   --output build/docs \
   --head "$(cat bin/gen-doc-head.html)"
 


### PR DESCRIPTION
still excluding src/generated/ , where proto-generated headers live.
(compared to Javadoc for protobufs, they're pretty good.
But if there's no comment for a field, the jazzy doc is not so
useful ("undocumented", no type info); and we have many uncommented fields.)