### PR TITLE
Add dev-key header to ErrorHandlerTests

### DIFF
--- a/tests/TKErrorHandlerTests.m
+++ b/tests/TKErrorHandlerTests.m
@@ -57,6 +57,7 @@
                                     }];
         call.requestHeaders[@"token-sdk"] = @"objc";
         call.requestHeaders[@"token-sdk-version"] = @"0.0.1";
+        call.requestHeaders[@"token-dev-key"] = [self sdkBuilder].developerKey;
 
         @try {
             [syncCall run:^{


### PR DESCRIPTION
Once dev-key becomes required this test will throw the wrong error.