### PR TITLE
Sl.la

### DIFF
--- a/src/api/TokenIOBuilder.h
+++ b/src/api/TokenIOBuilder.h
@@ -35,6 +35,9 @@
 
 /// Crypto key storage. By default, uses Secure Enclave.
 @property (readwrite) id<TKKeyStore> keyStore;
+
+/// If you are using your own key storage, Token crypto engine will ask for local authentication when you sign data by default. Disables this will skip the local authentication.
+@property (readwrite) BOOL useLocalAuthentication;
 /**
  * Optional callback to invoke when a cross-cutting RPC error is raised (for example: kTKErrorSdkVersionMismatch).
  * This is in addition to the rpc-specific onError handler, which is still invoked after the rpcErrorCallback.

--- a/src/api/TokenIOBuilder.m
+++ b/src/api/TokenIOBuilder.m
@@ -25,6 +25,7 @@
         self.port = 9000;
         self.timeoutMs = 60 * 1000; // 60 seconds.
         self.useSsl = YES;
+        self.useLocalAuthentication = YES;
         self.globalRpcErrorCallback = ^(NSError *error) {/* noop default callback */};
     }
 
@@ -39,7 +40,8 @@
 - (TokenIO *)buildAsync {
     id<TKCryptoEngineFactory> cryptoEngineFactory;
     if (self.keyStore) {
-        cryptoEngineFactory = [TKTokenCryptoEngineFactory factoryWithStore:self.keyStore];
+        cryptoEngineFactory = [TKTokenCryptoEngineFactory factoryWithStore:self.keyStore
+                                                    useLocalAuthentication:self.useLocalAuthentication];
     } else {
         cryptoEngineFactory = [[TKSecureEnclaveCryptoEngineFactory alloc] init];
     }

--- a/src/security/token/TKTokenCryptoEngine.h
+++ b/src/security/token/TKTokenCryptoEngine.h
@@ -14,6 +14,8 @@
  */
 @interface TKTokenCryptoEngine : NSObject<TKCryptoEngine>
 
-- (id)initForMember:(NSString *)memberId useKeyStore:(id <TKKeyStore>)store_ useLocalAuthentication:(BOOL)useLocalAuthentication;
+- (id)initForMember:(NSString *)memberId
+        useKeyStore:(id <TKKeyStore>)store_
+useLocalAuthentication:(BOOL)useLocalAuthentication;
 
 @end

--- a/src/security/token/TKTokenCryptoEngine.h
+++ b/src/security/token/TKTokenCryptoEngine.h
@@ -14,6 +14,6 @@
  */
 @interface TKTokenCryptoEngine : NSObject<TKCryptoEngine>
 
-- (id)initForMember:(NSString *)memberId useKeyStore:(id <TKKeyStore>)store_;
+- (id)initForMember:(NSString *)memberId useKeyStore:(id <TKKeyStore>)store_ useLocalAuthentication:(BOOL)useLocalAuthentication;
 
 @end

--- a/src/security/token/TKTokenCryptoEngine.m
+++ b/src/security/token/TKTokenCryptoEngine.m
@@ -53,8 +53,6 @@
             usingKeyLevel:(Key_Level)keyLevel
                    reason:(NSString *)reason
                   onError:(OnError)onError {
-    LAContext *context = [[LAContext alloc] init];
-    
     if (!useLocalAuthentication) {
         return [self createSignature:data usingKeyLevel:keyLevel];
     }
@@ -63,6 +61,8 @@
         // We don't check DeviceOwnerAuthentication for Key_Level_Low
         return [self createSignature:data usingKeyLevel:keyLevel];
     }
+    
+    LAContext *context = [[LAContext alloc] init];
     
     if (![context canEvaluatePolicy:LAPolicyDeviceOwnerAuthentication error:nil]) {
         // If device don't support Device Owner Authentication, skip as success

--- a/src/security/token/TKTokenCryptoEngine.m
+++ b/src/security/token/TKTokenCryptoEngine.m
@@ -65,7 +65,7 @@
     LAContext *context = [[LAContext alloc] init];
     
     if (![context canEvaluatePolicy:LAPolicyDeviceOwnerAuthentication error:nil]) {
-        // If device don't support Device Owner Authentication, skip as success
+        // If device doesn't support Device Owner Authentication, skip as success
         return [self createSignature:data usingKeyLevel:keyLevel];
     }
     
@@ -73,10 +73,11 @@
     __block TKSignature *signature = nil;
     __block NSError *laError = nil;
     
+    // This method will pop up a modal for passcode or touch ID
     [context evaluatePolicy:LAPolicyDeviceOwnerAuthentication
             localizedReason:reason
                       reply:^(BOOL success, NSError *error) {
-                          // This is a backend thread
+                          // This is not the main thread
                           if (success) {
                               signature = [self createSignature:data usingKeyLevel:keyLevel];
                           }

--- a/src/security/token/TKTokenCryptoEngineFactory.h
+++ b/src/security/token/TKTokenCryptoEngineFactory.h
@@ -11,6 +11,7 @@
 
 @interface TKTokenCryptoEngineFactory : NSObject<TKCryptoEngineFactory>
 
-+ (id<TKCryptoEngineFactory>)factoryWithStore:(id<TKKeyStore>)storage;
++ (id<TKCryptoEngineFactory>)factoryWithStore:(id<TKKeyStore>)storage
+                       useLocalAuthentication:(BOOL)useLocalAuthentication;
 
 @end

--- a/src/security/token/TKTokenCryptoEngineFactory.m
+++ b/src/security/token/TKTokenCryptoEngineFactory.m
@@ -18,7 +18,8 @@
                                         useLocalAuthentication:useLocalAuthentication];
 }
 
-- (id)initWithStorage:(id<TKKeyStore>)storage_ useLocalAuthentication:(BOOL)useLocalAuthentication_ {
+- (id)initWithStorage:(id<TKKeyStore>)storage_
+useLocalAuthentication:(BOOL)useLocalAuthentication_ {
     self = [super init];
 
     if (self) {

--- a/src/security/token/TKTokenCryptoEngineFactory.m
+++ b/src/security/token/TKTokenCryptoEngineFactory.m
@@ -9,24 +9,30 @@
 
 @implementation TKTokenCryptoEngineFactory {
     id<TKKeyStore> storage;
+    BOOL useLocalAuthentication;
 }
 
-+ (id<TKCryptoEngineFactory>)factoryWithStore:(id<TKKeyStore>)storage {
-    return [[TKTokenCryptoEngineFactory alloc] initWithStorage:storage];
++ (id<TKCryptoEngineFactory>)factoryWithStore:(id<TKKeyStore>)storage
+                       useLocalAuthentication:(BOOL)useLocalAuthentication {
+    return [[TKTokenCryptoEngineFactory alloc] initWithStorage:storage
+                                        useLocalAuthentication:useLocalAuthentication];
 }
 
-- (id)initWithStorage:(id<TKKeyStore>)storage_ {
+- (id)initWithStorage:(id<TKKeyStore>)storage_ useLocalAuthentication:(BOOL)useLocalAuthentication_ {
     self = [super init];
 
     if (self) {
         storage = storage_;
+        useLocalAuthentication = useLocalAuthentication_;
     }
 
     return self;
 }
 
 - (id<TKCryptoEngine>)createEngine:(NSString *)memberId {
-    return [[TKTokenCryptoEngine alloc] initForMember:memberId useKeyStore:storage];
+    return [[TKTokenCryptoEngine alloc] initForMember:memberId
+                                          useKeyStore:storage
+                               useLocalAuthentication:useLocalAuthentication];
 }
 
 @end

--- a/tests/TKCryptoTests.m
+++ b/tests/TKCryptoTests.m
@@ -21,7 +21,7 @@
 - (void)setUp {
     [super setUp];
     id<TKKeyStore> store = [[TKInMemoryKeyStore alloc] init];
-    id<TKCryptoEngine> engine = [[TKTokenCryptoEngineFactory factoryWithStore:store] createEngine:@"member_id_123"];
+    id<TKCryptoEngine> engine = [[TKTokenCryptoEngineFactory factoryWithStore:store useLocalAuthentication:NO] createEngine:@"member_id_123"];
     crypto = [[TKCrypto alloc] initWithEngine:engine];
 }
 

--- a/tests/TKTestBase.m
+++ b/tests/TKTestBase.m
@@ -45,16 +45,17 @@
 
 // create an SDK client builder with settings appropriate for testing environment
 - (TokenIOBuilder *)sdkBuilder {
-  HostAndPort *gateway = [self hostAndPort:@"TOKEN_GATEWAY" withDefaultPort:9000];
-
-  TokenIOBuilder *builder = [TokenIOSync builder];
-  builder.host = gateway.host;
-  builder.port = gateway.port;
-  builder.useSsl = useSsl;
-  builder.timeoutMs = 10 * 60 * 1000; // 10 minutes timeout to make debugging easier.
-  builder.developerKey = @"4qY7lqQw8NOl9gng0ZHgT4xdiDqxqoGVutuZwrUYQsI";
-  builder.keyStore = [[TKInMemoryKeyStore alloc] init];
-  return builder;
+    HostAndPort *gateway = [self hostAndPort:@"TOKEN_GATEWAY" withDefaultPort:9000];
+    
+    TokenIOBuilder *builder = [TokenIOSync builder];
+    builder.host = gateway.host;
+    builder.port = gateway.port;
+    builder.useSsl = useSsl;
+    builder.timeoutMs = 10 * 60 * 1000; // 10 minutes timeout to make debugging easier.
+    builder.developerKey = @"4qY7lqQw8NOl9gng0ZHgT4xdiDqxqoGVutuZwrUYQsI";
+    builder.keyStore = [[TKInMemoryKeyStore alloc] init];
+    builder.useLocalAuthentication = NO;
+    return builder;
 }
 
 - (TokenIO *)asyncSDK {


### PR DESCRIPTION
Token Crypto Engine shall popup the passcode page when we want to sign data with privilege and standard key. (the same as secure enclave engine).
If you have a iphone 5 and you have set your passcode, you will need this.

Test cases code can set useLocalAuthentication = false to avoid the check.