### PR TITLE
add certspath in tokeniobuilder

### DIFF
--- a/src/api/TokenIO.h
+++ b/src/api/TokenIO.h
@@ -50,7 +50,7 @@
  * @param developerKey developer ID
  * @param cryptoEngineFactory crypto module to use
  * @param useSsl use SSL if true
- * @param certsPath use custom certs if set
+ * @param certsPath use custom certs; otherwise, use the default root certs
  * @param globalRpcErrorCallback global RPC error callback to invoke on error
  */
 - (id)initWithHost:(NSString *)host

--- a/src/api/TokenIO.h
+++ b/src/api/TokenIO.h
@@ -50,6 +50,7 @@
  * @param developerKey developer ID
  * @param cryptoEngineFactory crypto module to use
  * @param useSsl use SSL if true
+ * @param certsPath use custom certs if set
  * @param globalRpcErrorCallback global RPC error callback to invoke on error
  */
 - (id)initWithHost:(NSString *)host
@@ -58,6 +59,7 @@
       developerKey:(NSString *)developerKey
             crypto:(id<TKCryptoEngineFactory>)cryptoEngineFactory
             useSsl:(BOOL)useSsl
+         certsPath:(NSString *)certsPath
 globalRpcErrorCallback:(OnError)globalRpcErrorCallback;
 
 /**

--- a/src/api/TokenIO.m
+++ b/src/api/TokenIO.m
@@ -69,16 +69,12 @@ globalRpcErrorCallback:(OnError)globalRpcErrorCallback_ {
                                                         encoding:NSUTF8StringEncoding
                                                            error:&error];
             if (error) {
-                @throw [NSException exceptionWithName:@"InvalidCertificateException"
-                                               reason:@"The certificate data is invalid."
-                                             userInfo:nil];
+                @throw error;
             }
             
             [GRPCCall setTLSPEMRootCerts:certs forHost:address error:&error];
             if (error) {
-                @throw [NSException exceptionWithName:@"InvalidCertificateException"
-                                               reason:@"The certificate data is invalid."
-                                             userInfo:nil];
+                @throw error;
             }
         }
         [GRPCCall setUserAgentPrefix:@"Token-iOS/1.0" forHost:address];

--- a/src/api/TokenIO.m
+++ b/src/api/TokenIO.m
@@ -5,6 +5,7 @@
 
 #import <Foundation/Foundation.h>
 #import <GRPCClient/GRPCCall+ChannelArg.h>
+#import <GRPCClient/GRPCCall+ChannelCredentials.h>
 #import <GRPCClient/GRPCCall+Tests.h>
 
 #import "gateway/Gateway.pbrpc.h"
@@ -18,7 +19,6 @@
 #import "TKRpcErrorHandler.h"
 #import "TKLocalizer.h"
 #import "TKMemberRecoveryManager.h"
-
 
 @implementation TokenIO {
     GatewayService *gateway;
@@ -48,6 +48,7 @@
       developerKey:(NSString *)developerKey_
             crypto:(id<TKCryptoEngineFactory>)cryptoEngineFactory_
             useSsl:(BOOL)useSsl
+         certsPath:(NSString *)certsPath
 globalRpcErrorCallback:(OnError)globalRpcErrorCallback_ {
     if (!developerKey_) {
         @throw [NSException exceptionWithName:@"NoDeveloperKeyException"
@@ -62,7 +63,24 @@ globalRpcErrorCallback:(OnError)globalRpcErrorCallback_ {
         if (!useSsl) {
             [GRPCCall useInsecureConnectionsForHost:address];
         }
-        [GRPCCall setUserAgentPrefix:@"Token-iOS/1.0" forHost:address];
+        if (certsPath) {
+            NSError *error = nil;
+            NSString *certs = [NSString stringWithContentsOfFile:certsPath
+                                                        encoding:NSUTF8StringEncoding
+                                                           error:&error];
+            if (error) {
+                @throw [NSException exceptionWithName:@"InvalidCertificateException"
+                                               reason:@"The certificate data is invalid."
+                                             userInfo:nil];
+            }
+            
+            [GRPCCall setTLSPEMRootCerts:certs forHost:address error:&error];
+            if (error) {
+                @throw [NSException exceptionWithName:@"InvalidCertificateException"
+                                               reason:@"The certificate data is invalid."
+                                             userInfo:nil];
+            }
+        }
         [GRPCCall setUserAgentPrefix:@"Token-iOS/1.0" forHost:address];
 
         gateway = [GatewayService serviceWithHost:address];

--- a/src/api/TokenIOBuilder.h
+++ b/src/api/TokenIOBuilder.h
@@ -38,6 +38,9 @@
 
 /// If you are using your own key storage, Token crypto engine will ask for local authentication when you sign data by default. Disables this will skip the local authentication.
 @property (readwrite) BOOL useLocalAuthentication;
+
+/// Uses custom grpc certs.
+@property (readwrite, copy) NSString *certsPath;
 /**
  * Optional callback to invoke when a cross-cutting RPC error is raised (for example: kTKErrorSdkVersionMismatch).
  * This is in addition to the rpc-specific onError handler, which is still invoked after the rpcErrorCallback.

--- a/src/api/TokenIOBuilder.m
+++ b/src/api/TokenIOBuilder.m
@@ -48,12 +48,13 @@
 
     return [[TokenIO alloc]
             initWithHost:self.host
-                    port:self.port
-               timeoutMs:self.timeoutMs
+            port:self.port
+            timeoutMs:self.timeoutMs
             developerKey:self.developerKey
-                  crypto:cryptoEngineFactory
-                  useSsl:self.useSsl
-  globalRpcErrorCallback:self.globalRpcErrorCallback];
+            crypto:cryptoEngineFactory
+            useSsl:self.useSsl
+            certsPath:self.certsPath
+            globalRpcErrorCallback:self.globalRpcErrorCallback];
 }
 
 @end

--- a/tests/TokenIOTests.m
+++ b/tests/TokenIOTests.m
@@ -31,6 +31,7 @@
                                      developerKey:@"4qY7lqQw8NOl9gng0ZHgT4xdiDqxqoGVutuZwrUYQsI"
                                            crypto:nil
                                            useSsl:NO
+                                        certsPath:nil
                            globalRpcErrorCallback:^(NSError *error) {/* noop default callback */}]);
 }
 
@@ -41,6 +42,7 @@
                                                   developerKey:nil
                                                         crypto:nil
                                                         useSsl:NO
+                                                     certsPath:nil
                                         globalRpcErrorCallback:^(NSError *error) {/* noop default callback */}],
                                  NSException,
                                  @"NoDeveloperKeyException");


### PR DESCRIPTION
if user sets custom certs path in token io builder, token io will create grpc channel with the given certs instead.
use in netcraft pan testing.