### PR TITLE
getTransfers: use filter.tokenId instead of tokenId, it's newer

### DIFF
--- a/src/rpc/TKClient.m
+++ b/src/rpc/TKClient.m
@@ -773,7 +773,7 @@
     GetTransfersRequest *request = [GetTransfersRequest message];
     request.page.offset = offset;
     request.page.limit = limit;
-    request.tokenId = tokenId;
+    request.filter.tokenId = tokenId;
     RpcLogStart(request);
     
     GRPCProtoCall *call = [gateway


### PR DESCRIPTION
When I look at the gateway change https://github.com/tokenio/gateway/commit/0f57e81f12740ee5052db40634d950510e87d9a0 , I ?think? it means we want this change in sdk-objc.