### PR TITLE
sample code += use access token that maybe does not have allAccounts

### DIFF
--- a/sample/TKAccessSamples.m
+++ b/sample/TKAccessSamples.m
@@ -103,9 +103,13 @@
     
         return (foundToken != nil) && [foundToken.id_p isEqual:accessToken.id_p];
     } backOffTimeMs:1000];
+    
+    NSLog(@"I see foundToken %@ ", foundToken);
 
     // replaceAndEndorseAccessToken begin snippet to include in docs
     AccessTokenConfig *newAccess = [AccessTokenConfig fromPayload:foundToken.payload];
+    [newAccess forAllAccounts];
+    [newAccess forAllBalances];
     [newAccess forAllAddresses];
     
     [grantor replaceAndEndorseAccessToken:foundToken

--- a/sample/TKAccessSamples.m
+++ b/sample/TKAccessSamples.m
@@ -104,8 +104,6 @@
         return (foundToken != nil) && [foundToken.id_p isEqual:accessToken.id_p];
     } backOffTimeMs:1000];
     
-    NSLog(@"I see foundToken %@ ", foundToken);
-
     // replaceAndEndorseAccessToken begin snippet to include in docs
     AccessTokenConfig *newAccess = [AccessTokenConfig fromPayload:foundToken.payload];
     [newAccess forAllAccounts];
@@ -142,9 +140,6 @@
     // cancelToken done snippet to include in docs
     
     [self runUntilTrue:^ {
-        NSLog(@"REPLACE I see sig count %d", (int)accessToken.payloadSignaturesArray_Count);
-        NSLog(@"        I see sig %@", accessToken.payloadSignaturesArray[0]);
-        NSLog(@"        I see sig %@", accessToken.payloadSignaturesArray[1]);
         return (accessToken.payloadSignaturesArray_Count > 3);
     }];
 }

--- a/tests/TKTransactionsTests.m
+++ b/tests/TKTransactionsTests.m
@@ -39,10 +39,10 @@
     [self run: ^(TokenIOSync *tokenIO) {
         TKBalance *balance = [payerAccount getBalance];
         Money *currentBalance = balance.current;
-        XCTAssert(currentBalance.value > 0);
+        XCTAssert([currentBalance.value intValue] > 0);
         XCTAssertEqualObjects(@"USD", currentBalance.currency);
         Money *availableBalance = balance.available;
-        XCTAssert(availableBalance.value > 0);
+        XCTAssert([availableBalance.value intValue] > 0);
         XCTAssertEqualObjects(@"USD", availableBalance.currency);
     }];     
 }


### PR DESCRIPTION
so far, our redeem-access-token sample code shows how to use a token that has allAccounts. But if the token-grantor replaces that allAccounts with something more specific, e.g., edits the permissions in our iPhone app, that sample code fails to fetch any data. This new sample code shows how to use allAccounts if granted else use more-specific permissions.

bonus: fix old replace-access sample mistake: it was trying to set new config by calling methods on old config

bonus: fix a test that was comparing a pointer to string "10" being above 0, rather than converting that "10" to an int. it worked in that context, but was confusing.