### PR TITLE
add crypto engine to TokenIOBuilder

### DIFF
--- a/TokenSdk.podspec
+++ b/TokenSdk.podspec
@@ -42,7 +42,7 @@ Pod::Spec.new do |s|
                 "#{gendir}/*.pbrpc.m", "#{gendir}/**/*.pbrpc.m"
         ss.ios.source_files = "src/authorization/ios/*.{h,c,m}"
         ss.requires_arc = true
-        ss.public_header_files = "src/api", "src/security", "src/security/se", "src/authorization/", "src/security/token", "src/util"
+        ss.public_header_files = "src/api", "src/security", "src/security/secureenclave", "src/authorization/", "src/security/token", "src/util"
         ss.ios.public_header_files =  "src/authorization/ios"
         ss.exclude_files = "**/*_test.*","**/test_*.*","**/test/*.*","**/test.*", "#{gendir}/fank/*"
         ss.dependency "gRPC-ProtoRPC"

--- a/sample/TKSetupSamples.m
+++ b/sample/TKSetupSamples.m
@@ -12,6 +12,7 @@
 #import "DeviceInfo.h"
 #import "TKSampleBase.h"
 #import "TKInMemoryKeyStore.h"
+#import "TKTokenCryptoEngineFactory.h"
 
 // These "tests" are snippets of sample code that get included in
 // our web documentation (plus some test code to make sure the
@@ -116,7 +117,8 @@
     // (as would happen if they used the "regular" keystore).
     id<TKKeyStore> store = [[TKInMemoryKeyStore alloc] init];
     TokenIOBuilder *beforeBuilder = [self sdkBuilder];
-    beforeBuilder.keyStore = store;
+    beforeBuilder.cryptoEngineFactory = [TKTokenCryptoEngineFactory factoryWithStore:store
+                                                              useLocalAuthentication:NO];
     TokenIO *beforeTokenIO = [beforeBuilder buildAsync];
     
     Alias *alias = [Alias new];
@@ -133,7 +135,8 @@
     }];
     NSString *memberId = member.id;
     TokenIOBuilder *builder = [self sdkBuilder];
-    builder.keyStore = store;
+    builder.cryptoEngineFactory = [TKTokenCryptoEngineFactory factoryWithStore:store
+                                                        useLocalAuthentication:NO];
     TokenIO *tokenIO = [builder buildAsync];
     
     __block TKMember *loggedInMember;
@@ -159,7 +162,9 @@
     // We have two sdks, one for our new device, one for our "main" device.
     // Each needs its own keystore: provisionDevice _replaces_ keys.
     TokenIOBuilder *builder = [self sdkBuilder];
-    builder.keyStore = [[TKInMemoryKeyStore alloc] init];
+    id<TKKeyStore> store = [[TKInMemoryKeyStore alloc] init];
+    builder.cryptoEngineFactory = [TKTokenCryptoEngineFactory factoryWithStore:store
+                                                        useLocalAuthentication:NO];
     TokenIO *tokenIO = [builder buildAsync];
     Alias *memberAlias = self.payerAlias;
     __block Key *sentKey = nil;
@@ -226,9 +231,11 @@
     // Create a new SDK client with its own keystore to make sure
     // we don't interfere with/use keys used to create the member
     TokenIOBuilder *builder = [self sdkBuilder];
-    builder.keyStore = [[TKInMemoryKeyStore alloc] init];
+    id<TKKeyStore> store = [[TKInMemoryKeyStore alloc] init];
+    builder.cryptoEngineFactory = [TKTokenCryptoEngineFactory factoryWithStore:store
+                                                        useLocalAuthentication:NO];
     TokenIO *tokenIO = [builder buildAsync];
-    __block int prompting = false;
+    __block int prompting = NO;
 
     void (^showPrompt)(NSString *s) = ^(NSString *s) {
         prompting = true;
@@ -247,7 +254,7 @@
     // beginRecovery done snippet to include in docs
 
     [self runUntilTrue:^ {
-        return (prompting != false);
+        return (prompting != NO);
     }];
 
     NSString *userEnteredCode = @"1thru6"; // The test users can bypass the verification, so any code works.

--- a/sample/TKSetupSamples.m
+++ b/sample/TKSetupSamples.m
@@ -238,7 +238,7 @@
     __block int prompting = NO;
 
     void (^showPrompt)(NSString *s) = ^(NSString *s) {
-        prompting = true;
+        prompting = YES;
     };
 
     // beginRecovery begin snippet to include in docs

--- a/src/api/TKMemberRecoveryManager.h
+++ b/src/api/TKMemberRecoveryManager.h
@@ -37,34 +37,49 @@
  * be sent if the alias is valid. All the member recovery methods shall be called by the same
  * TKMemberRecoveryManager instance.
  *
- * @param aliasValue alias value to recover
- * @param onSuccess invoked if successful
+ * @param alias alias to recover
+ * @param onSuccess invoked if successful with verification Id
  * @param onError invoked if failed
  */
-- (void)beginMemberRecovery:(NSString *)aliasValue
-                  onSuccess:(OnSuccess)onSuccess
+
+- (void)beginMemberRecovery:(Alias *)alias
+                  onSuccess:(OnSuccessWithString)onSuccess
                     onError:(OnError)onError;
 
 /**
  * Verifies member recovery code after beginMemberRecovery is successful. All the member recovery
  * methods shall be called by the same TKMemberRecoveryManager instance.
  *
+ * @param alias alias to recover
+ * @param memberId memberId to recover
+ * @param verificationId verification Id from beginMemberRecovery call
  * @param code code from verification message
  * @param onSuccess invoked if successful
  * @param onError invoked if failed
  */
-- (void)verifyMemberRecoveryCode:(NSString *)code
-                       onSuccess:(OnSuccessWithBoolean)onSuccess
-                         onError:(OnError)onError;
+- (void)verifyMemberRecovery:(Alias *)alias
+                    memberId:(NSString *)memberId
+              verificationId:(NSString *)verificationId
+                        code:(NSString *)code
+                   onSuccess:(OnSuccessWithBoolean)onSuccess
+                     onError:(OnError)onError;
 
 /**
  * Completes member recovery process after verifyMemberRecoveryCode is successful. Uploads member's
  * public keys from this device to Token directory. All the member recovery methods shall be called
  * by the same TKMemberRecoveryManager instance.
  *
+ * @param alias alias to recover
+ * @param memberId memberId to recover
+ * @param verificationId verification Id from beginMemberRecovery call
+ * @param code code from verification message
  * @param onSuccess invoked if successful with TkMember
  * @param onError invoked if failed
  */
-- (void)completeMemberRecovery:(OnSuccessWithTKMember)onSuccess
+- (void)completeMemberRecovery:(Alias *)alias
+                      memberId:(NSString *)memberId
+                verificationId:(NSString *)verificationId
+                          code:(NSString *)code
+                     onSuccess:(OnSuccessWithTKMember)onSuccess
                        onError:(OnError)onError;
 @end

--- a/src/api/TokenIO.h
+++ b/src/api/TokenIO.h
@@ -198,35 +198,50 @@ globalRpcErrorCallback:(OnError)globalRpcErrorCallback;
  * be sent if the alias is valid. All the member recovery methods shall be called by the same
  * TokenIO instance.
  *
- * @param aliasValue alias value to recover
- * @param onSuccess invoked if successful
+ * @param alias alias to recover
+ * @param onSuccess invoked if successful with verification Id
  * @param onError invoked if failed
  */
-- (void)beginMemberRecovery:(NSString *)aliasValue
-                  onSuccess:(OnSuccess)onSuccess
+
+- (void)beginMemberRecovery:(Alias *)alias
+                  onSuccess:(OnSuccessWithString)onSuccess
                     onError:(OnError)onError;
 
 /**
  * Verifies member recovery code after beginMemberRecovery is successful. All the member recovery
  * methods shall be called by the same TokenIO instance.
  *
+ * @param alias alias to recover
+ * @param memberId memberId to recover
+ * @param verificationId verification Id from beginMemberRecovery call
  * @param code code from verification message
  * @param onSuccess invoked if successful
  * @param onError invoked if failed
  */
-- (void)verifyMemberRecoveryCode:(NSString *)code
-                       onSuccess:(OnSuccessWithBoolean)onSuccess
-                         onError:(OnError)onError;
+- (void)verifyMemberRecovery:(Alias *)alias
+                    memberId:(NSString *)memberId
+              verificationId:(NSString *)verificationId
+                        code:(NSString *)code
+                   onSuccess:(OnSuccessWithBoolean)onSuccess
+                     onError:(OnError)onError;
 
 /**
  * Completes member recovery process after verifyMemberRecoveryCode is successful. Uploads member's
  * public keys from this device to Token directory. All the member recovery methods shall be called
  * by the same TokenIO instance.
  *
+ * @param alias alias to recover
+ * @param memberId memberId to recover
+ * @param verificationId verification Id from beginMemberRecovery call
+ * @param code code from verification message
  * @param onSuccess invoked if successful with TkMember
  * @param onError invoked if failed
  */
-- (void)completeMemberRecovery:(OnSuccessWithTKMember)onSuccess
+- (void)completeMemberRecovery:(Alias *)alias
+                      memberId:(NSString *)memberId
+                verificationId:(NSString *)verificationId
+                          code:(NSString *)code
+                     onSuccess:(OnSuccessWithTKMember)onSuccess
                        onError:(OnError)onError;
 
 @end

--- a/src/api/TokenIO.m
+++ b/src/api/TokenIO.m
@@ -272,25 +272,39 @@ globalRpcErrorCallback:(OnError)globalRpcErrorCallback_ {
 
 #pragma mark - Member Recovery
 
-- (void)beginMemberRecovery:(NSString *)aliasValue
-                  onSuccess:(OnSuccess)onSuccess
+- (void)beginMemberRecovery:(Alias *)alias
+                  onSuccess:(OnSuccessWithString)onSuccess
                     onError:(OnError)onError {
-    [memberRecoveryManager beginMemberRecovery:aliasValue
+    [memberRecoveryManager beginMemberRecovery:alias
                                      onSuccess:onSuccess
                                        onError:onError];
 }
 
-- (void)verifyMemberRecoveryCode:(NSString *)code
-                       onSuccess:(OnSuccessWithBoolean)onSuccess
-                         onError:(OnError)onError {
-    [memberRecoveryManager verifyMemberRecoveryCode:code
-                                          onSuccess:onSuccess
-                                            onError:onError];
+- (void)verifyMemberRecovery:(Alias *)alias
+                    memberId:(NSString *)memberId
+              verificationId:(NSString *)verificationId
+                        code:(NSString *)code
+                   onSuccess:(OnSuccessWithBoolean)onSuccess
+                     onError:(OnError)onError {
+    [memberRecoveryManager verifyMemberRecovery:alias
+                                       memberId:memberId
+                                 verificationId:verificationId
+                                           code:code
+                                      onSuccess:onSuccess
+                                        onError:onError];
 }
 
-- (void)completeMemberRecovery:(OnSuccessWithTKMember)onSuccess
+- (void)completeMemberRecovery:(Alias *)alias
+                      memberId:(NSString *)memberId
+                verificationId:(NSString *)verificationId
+                          code:(NSString *)code
+                     onSuccess:(OnSuccessWithTKMember)onSuccess
                        onError:(OnError)onError {
-    [memberRecoveryManager completeMemberRecovery:onSuccess
+    [memberRecoveryManager completeMemberRecovery:alias
+                                         memberId:memberId
+                                   verificationId:verificationId
+                                             code:code
+                                        onSuccess:onSuccess
                                           onError:onError];
 }
 

--- a/src/api/TokenIOBuilder.h
+++ b/src/api/TokenIOBuilder.h
@@ -40,14 +40,12 @@
 /// Use SSL to protect connection?
 @property (readwrite) BOOL useSsl;
 
-/// Crypto key storage. By default, uses Secure Enclave.
-@property (readwrite) id<TKKeyStore> keyStore;
-
 /**
- * If you are using your own key storage, Token crypto engine will ask for local
- * authentication when you sign data by default. Disables this will skip the local authentication.
+ * Set this property if you prefer a customized crypto engine factory.
+ * You can use TKTokenCryptoEngineFactory for a customized keyStore.
+ * Token Sdk will use TKSecureEnclaveCryptoEngineFactory by default.
  */
-@property (readwrite) BOOL useLocalAuthentication;
+@property (readwrite) id<TKCryptoEngineFactory> cryptoEngineFactory;
 
 /// Uses custom grpc certs.
 @property (readwrite, copy) NSString *certsPath;

--- a/src/api/TokenIOBuilder.m
+++ b/src/api/TokenIOBuilder.m
@@ -27,7 +27,6 @@
         self.port = 9000;
         self.timeoutMs = 60 * 1000; // 60 seconds.
         self.useSsl = YES;
-        self.useLocalAuthentication = YES;
         self.globalRpcErrorCallback = ^(NSError *error) {/* noop default callback */};
     }
 
@@ -40,12 +39,9 @@
 }
 
 - (TokenIO *)buildAsync {
-    id<TKCryptoEngineFactory> cryptoEngineFactory;
-    if (self.keyStore) {
-        cryptoEngineFactory = [TKTokenCryptoEngineFactory factoryWithStore:self.keyStore
-                                                    useLocalAuthentication:self.useLocalAuthentication];
-    } else {
-        cryptoEngineFactory = [[TKSecureEnclaveCryptoEngineFactory alloc] init];
+    if (!self.cryptoEngineFactory) {
+        self.cryptoEngineFactory =
+        [TKSecureEnclaveCryptoEngineFactory factoryWithAuthenticationOption:false];
     }
     
 #if TARGET_OS_IPHONE
@@ -62,7 +58,7 @@
             timeoutMs:self.timeoutMs
             developerKey:self.developerKey
             languageCode:self.languageCode
-            crypto:cryptoEngineFactory
+            crypto:self.cryptoEngineFactory
             browserFactory:self.browserFactory
             useSsl:self.useSsl
             certsPath:self.certsPath

--- a/src/api/TokenIOSync.h
+++ b/src/api/TokenIOSync.h
@@ -152,26 +152,39 @@
  * be sent if the alias is valid. All the member recovery methods shall be called by the same
  * TokenIOSync instance.
  *
- * @param aliasValue alias value to recover
+ * @param alias alias to recover
+ * @return verificationId for the recovery process
  */
-- (void)beginMemberRecovery:(NSString *)aliasValue;
+- (NSString* )beginMemberRecovery:(Alias *)alias;
 
 /**
  * Verifies member recovery code after beginMemberRecovery is successful. All the member recovery
  * methods shall be called by the same TokenIOSync instance.
  *
+ * @param alias alias to recover
+ * @param memberId memberId to recover
+ * @param verificationId verification Id from beginMemberRecovery call
  * @param code code from verification message
  * @return Boolean if the code is correct
  */
-- (BOOL)verifyMemberRecoveryCode:(NSString *)code;
+- (BOOL)verifyMemberRecovery:(Alias *)alias
+                    memberId:(NSString *)memberId
+              verificationId:(NSString *)verificationId
+                        code:(NSString *)code;
 
 /**
  * Completes member recovery process after verifyMemberRecoveryCode is successful. Uploads member's
  * public keys from this device to Token directory. All the member recovery methods shall be called
  * by the same TokenIO instance.
  *
- * @return recovered member
+ * @param alias alias to recover
+ * @param memberId memberId to recover
+ * @param verificationId verification Id from beginMemberRecovery call
+ * @param code code from verification message
  */
-- (TKMemberSync *)completeMemberRecovery;
+- (TKMemberSync *)completeMemberRecovery:(Alias *)alias
+                                memberId:(NSString *)memberId
+                          verificationId:(NSString *)verificationId
+                                    code:(NSString *)code;
 
 @end

--- a/src/api/TokenIOSync.m
+++ b/src/api/TokenIOSync.m
@@ -167,37 +167,50 @@
 
 #pragma mark - Member Recovery
 
-- (void)beginMemberRecovery:(NSString *)aliasValue {
-    TKRpcSyncCall<NSObject *> *call = [TKRpcSyncCall create];
-    [call run:^{
-        [self.async beginMemberRecovery:aliasValue
-                              onSuccess:^() {
-                                  call.onSuccess(nil);
+- (NSString* )beginMemberRecovery:(Alias *)alias {
+    TKRpcSyncCall<NSString *> *call = [TKRpcSyncCall create];
+    return [call run:^{
+        [self.async beginMemberRecovery:alias
+                              onSuccess:^(NSString *verificationId) {
+                                  call.onSuccess(verificationId);
                               } onError:call.onError];
     }];
 }
 
 
-- (BOOL)verifyMemberRecoveryCode:(NSString *)code {
+- (BOOL)verifyMemberRecovery:(Alias *)alias
+                    memberId:(NSString *)memberId
+              verificationId:(NSString *)verificationId
+                        code:(NSString *)code {
     TKRpcSyncCall<NSNumber *> *call = [TKRpcSyncCall create];
     NSNumber *result = [call run:^{
-        [self.async verifyMemberRecoveryCode:code
-                                   onSuccess:^(BOOL correct) {
-                                       call.onSuccess(@(correct));
-                                   }
-                                     onError:call.onError];
+        [self.async verifyMemberRecovery:alias
+                                memberId:memberId
+                          verificationId:verificationId
+                                    code:code
+                               onSuccess:^(BOOL correct) {
+                                   call.onSuccess(@(correct));
+                               }
+                                 onError:call.onError];
     }];
     return [result boolValue];
 }
 
 
-- (TKMemberSync *)completeMemberRecovery {
+- (TKMemberSync *)completeMemberRecovery:(Alias *)alias
+                                memberId:(NSString *)memberId
+                          verificationId:(NSString *)verificationId
+                                    code:(NSString *)code; {
     TKRpcSyncCall<TKMemberSync *> *call = [TKRpcSyncCall create];
     return [call run:^{
-        [self.async completeMemberRecovery:^(TKMember *member) {
-            TKMemberSync* memberSync = [TKMemberSync member:member];
-            call.onSuccess(memberSync);
-        }
+        [self.async completeMemberRecovery:alias
+                                  memberId:memberId
+                            verificationId:verificationId
+                                      code:code
+                                 onSuccess:^(TKMember *member) {
+                                     TKMemberSync* memberSync = [TKMemberSync member:member];
+                                     call.onSuccess(memberSync);
+                                 }
                                    onError:call.onError];
     }];
 }

--- a/src/security/secureenclave/TKSecureEnclaveCryptoEngine.h
+++ b/src/security/secureenclave/TKSecureEnclaveCryptoEngine.h
@@ -11,6 +11,7 @@
 
 @interface TKSecureEnclaveCryptoEngine : NSObject<TKCryptoEngine>
 
-- (id)initWithMemberId:(NSString*)memberId;
+- (id)initWithMemberId:(NSString *)memberId
+  authenticationOption:(BOOL)useDevicePasscodeOnly;
 
 @end

--- a/src/security/secureenclave/TKSecureEnclaveCryptoEngine.m
+++ b/src/security/secureenclave/TKSecureEnclaveCryptoEngine.m
@@ -22,12 +22,15 @@ static NSString* kKeyHeader = @"3059301306072a8648ce3d020106082a8648ce3d03010703
 
 @implementation TKSecureEnclaveCryptoEngine {
     NSString* _memberId;
+    BOOL _useDevicePasscodeOnly;
 }
 
-- (id)initWithMemberId:(NSString *)memberId {
+- (id)initWithMemberId:(NSString *)memberId
+  authenticationOption:(BOOL)useDevicePasscodeOnly {
     self = [super init];
     if (self) {
         _memberId = memberId;
+        _useDevicePasscodeOnly = useDevicePasscodeOnly;
     }
     return self;
 }
@@ -125,7 +128,12 @@ static NSString* kKeyHeader = @"3059301306072a8648ce3d020106082a8648ce3d03010703
     CFErrorRef error = NULL;
     SecAccessControlCreateFlags accessFlags = kSecAccessControlPrivateKeyUsage;
     if (level < Key_Level_Low) {
-        accessFlags |= kSecAccessControlUserPresence; // Will require Touch ID/Passcode
+        if (_useDevicePasscodeOnly) {
+            accessFlags |= kSecAccessControlDevicePasscode; // Will require Passcode
+        }
+        else {
+            accessFlags |= kSecAccessControlUserPresence; // Will require FaceID/Touch ID/Passcode
+        }
     }
     SecAccessControlRef sacObject = SecAccessControlCreateWithFlags(
             kCFAllocatorDefault,

--- a/src/security/secureenclave/TKSecureEnclaveCryptoEngineFactory.h
+++ b/src/security/secureenclave/TKSecureEnclaveCryptoEngineFactory.h
@@ -11,4 +11,10 @@
 
 @interface TKSecureEnclaveCryptoEngineFactory : NSObject<TKCryptoEngineFactory>
 
+/**
+ * Create TKSecureEnclaveCryptoEngineFactory with customized authentication option.
+ * @param useDevicePasscodeOnly use device passcode to authenticate only.
+ */
++ (id<TKCryptoEngineFactory>)factoryWithAuthenticationOption:(BOOL)useDevicePasscodeOnly;
+
 @end

--- a/src/security/secureenclave/TKSecureEnclaveCryptoEngineFactory.m
+++ b/src/security/secureenclave/TKSecureEnclaveCryptoEngineFactory.m
@@ -9,10 +9,29 @@
 #import "TKSecureEnclaveCryptoEngineFactory.h"
 #import "TKSecureEnclaveCryptoEngine.h"
 
-@implementation TKSecureEnclaveCryptoEngineFactory
+@implementation TKSecureEnclaveCryptoEngineFactory {
+    BOOL _useDevicePasscodeOnly;
+}
+
++ (id<TKCryptoEngineFactory>)factoryWithAuthenticationOption:(BOOL)useDevicePasscodeOnly {
+    return [[TKSecureEnclaveCryptoEngineFactory alloc]
+            initWithAuthenticationOption:useDevicePasscodeOnly];
+    
+}
+
+- (id)initWithAuthenticationOption:(BOOL)useDevicePasscodeOnly {
+    self = [super init];
+    
+    if (self) {
+        _useDevicePasscodeOnly = useDevicePasscodeOnly;
+    }
+    
+    return self;
+}
 
 - (id<TKCryptoEngine>)createEngine:(NSString *)memberId {
-    return [[TKSecureEnclaveCryptoEngine alloc] initWithMemberId:memberId];
+    return [[TKSecureEnclaveCryptoEngine alloc] initWithMemberId:memberId
+                                            authenticationOption:_useDevicePasscodeOnly];
 }
 
 @end

--- a/src/security/token/TKTokenCryptoEngineFactory.h
+++ b/src/security/token/TKTokenCryptoEngineFactory.h
@@ -16,7 +16,7 @@
  * @param storage the customized key store
  * @param useLocalAuthentication require local authentication to sign data. If you are using your
  * own key storage, Token crypto engine will ask for local authentication when you sign data
- * by default. Disables this will skip the local authentication
+ * by default. Disabling this will skip the local authentication
  */
 + (id<TKCryptoEngineFactory>)factoryWithStore:(id<TKKeyStore>)storage
                        useLocalAuthentication:(BOOL)useLocalAuthentication;

--- a/src/security/token/TKTokenCryptoEngineFactory.h
+++ b/src/security/token/TKTokenCryptoEngineFactory.h
@@ -11,6 +11,13 @@
 
 @interface TKTokenCryptoEngineFactory : NSObject<TKCryptoEngineFactory>
 
+/**
+ * Create TKTokenCryptoEngineFactory with customized key store.
+ * @param storage the customized key store
+ * @param useLocalAuthentication require local authentication to sign data. If you are using your
+ * own key storage, Token crypto engine will ask for local authentication when you sign data
+ * by default. Disables this will skip the local authentication
+ */
 + (id<TKCryptoEngineFactory>)factoryWithStore:(id<TKKeyStore>)storage
                        useLocalAuthentication:(BOOL)useLocalAuthentication;
 

--- a/tests/TKTestBase.m
+++ b/tests/TKTestBase.m
@@ -14,6 +14,7 @@
 #import "TKAccountSync.h"
 #import "TKInMemoryKeyStore.h"
 #import "TKLogManager.h"
+#import "TKTokenCryptoEngineFactory.h"
 
 
 @implementation TKTestBase {
@@ -54,8 +55,9 @@
     builder.timeoutMs = 10 * 60 * 1000; // 10 minutes timeout to make debugging easier.
     builder.developerKey = @"4qY7lqQw8NOl9gng0ZHgT4xdiDqxqoGVutuZwrUYQsI";
     builder.languageCode = @"en";
-    builder.keyStore = [[TKInMemoryKeyStore alloc] init];
-    builder.useLocalAuthentication = NO;
+    id<TKKeyStore> store = [[TKInMemoryKeyStore alloc] init];
+    builder.cryptoEngineFactory = [TKTokenCryptoEngineFactory factoryWithStore:store
+                                                        useLocalAuthentication:NO];
     return builder;
 }
 


### PR DESCRIPTION
We need to support Secure Enclave + Passcode only in some case to pass Apple's review guideline.

In the new design, devs will need to set crypto engine factory instead of key store when they create a TokenIO. So that the devs can have broader options in customizing a crypto engine instead of only the key store.