### PR TITLE
jazzy doc tool, omit "docsets" cruft, please

### DIFF
--- a/bin/gen-doc
+++ b/bin/gen-doc
@@ -12,6 +12,7 @@ $(ruby -rubygems -e 'puts Gem.user_dir')/bin/jazzy \
   --clean \
   --author Token \
   --author_url https://developer.token.io \
+  --docset-path "/tmp/jazzy" \
   --github_url https://github.com/tokenio/sdk-objc \
   --umbrella-header 'src/api/TokenSdk.h' \
   --framework-root 'src' \


### PR DESCRIPTION
full-featured jazzy makes a spare "docsets" copy
of the docs plus a tarball. Handy, but not in
our context of building docs for our website and
wondering "what is this tarball doing here?".
So ask jazzy to make that "docsets" far far away.