### PR TITLE
Rd 839

### DIFF
--- a/src/api/TKMember.h
+++ b/src/api/TKMember.h
@@ -76,6 +76,15 @@
 - (void)clearAccessToken;
 
 /**
+ * Gets public keys Array for the member.
+ *
+ * @param onSuccess callback invoked on success
+ * @param onError callback invoked on error
+ */
+- (void)getKeys:(OnSuccessWithKeys)onSuccess
+        onError:(OnError)onError;
+
+/**
  * Approves a key owned by this member. The key is added to the list
  * of valid keys for the member.
  *

--- a/src/api/TKMember.h
+++ b/src/api/TKMember.h
@@ -42,8 +42,6 @@
 /// Member's aliases: emails, etc. In UI, user normally refers to member by alias.
 @property (readonly, retain) NSArray<Alias *> *aliases;
 
-/// Crypto keys.
-@property (readonly, retain) NSArray<Key *> *keys;
 
 /// Customized authorization browser creation block.
 @property (readonly, retain) TKBrowserFactory browserFactory;

--- a/src/api/TKMember.m
+++ b/src/api/TKMember.m
@@ -71,6 +71,7 @@
     return [NSArray arrayWithArray:aliases];
 }
 
+
 - (void)useAccessToken:(NSString *)accessTokenId {
     [client useAccessToken:accessTokenId];
 }
@@ -85,7 +86,7 @@
             onSuccess:^(Member * _Nonnull m) {
                 [member clear];
                 [member mergeFrom:m];
-                onSuccess(m.keysArray);
+                onSuccess(member.keysArray);
             } onError:onError];
 }
 

--- a/src/api/TKMember.m
+++ b/src/api/TKMember.m
@@ -81,11 +81,10 @@
 
 - (void)getKeys:(OnSuccessWithKeys)onSuccess
         onError:(OnError)onError {
-    __strong typeof(member) retainedMember = member;
     [client getMember:self.id
             onSuccess:^(Member * _Nonnull m) {
-                [retainedMember clear];
-                [retainedMember mergeFrom:m];
+                [member clear];
+                [member mergeFrom:m];
                 onSuccess(m.keysArray);
             } onError:onError];
 }

--- a/src/api/TKMember.m
+++ b/src/api/TKMember.m
@@ -67,14 +67,6 @@
     return aliases.count > 0 ? aliases[0] : nil;
 }
 
-- (NSArray<Key *> *)keys {
-    NSMutableArray<Key *> *result = [NSMutableArray array];
-    for (Key *key in member.keysArray) {
-        [result addObject:key];
-    }
-    return result;
-}
-
 - (NSArray<Alias *> *)aliases {
     return [NSArray arrayWithArray:aliases];
 }

--- a/src/api/TKMember.m
+++ b/src/api/TKMember.m
@@ -87,6 +87,17 @@
     [client clearAccessToken];
 }
 
+- (void)getKeys:(OnSuccessWithKeys)onSuccess
+        onError:(OnError)onError {
+    __strong typeof(member) retainedMember = member;
+    [client getMember:self.id
+            onSuccess:^(Member * _Nonnull m) {
+                [retainedMember clear];
+                [retainedMember mergeFrom:m];
+                onSuccess(m.keysArray);
+            } onError:onError];
+}
+
 - (void)approveKey:(Key *)key
          onSuccess:(OnSuccess)onSuccess
            onError:(OnError)onError {

--- a/src/api/TKMemberSync.h
+++ b/src/api/TKMemberSync.h
@@ -75,6 +75,13 @@
 - (void)clearAccessToken;
 
 /**
+ * Gets all active public keys.
+ *
+ * @return keys
+ */
+- (NSArray<Key *> *) getKeys;
+
+/**
  * Approves a key owned by this member. The key is added to the list
  * of valid keys for the member.
  *

--- a/src/api/TKMemberSync.m
+++ b/src/api/TKMemberSync.m
@@ -32,14 +32,6 @@
     return self.async.firstAlias;
 }
 
-- (NSArray<Key *> *)keys {
-    TKRpcSyncCall<id> *call = [TKRpcSyncCall create];
-    return [call run:^{
-        [self.async getKeys:call.onSuccess
-                    onError:call.onError];
-    }];
-}
-
 - (NSArray<Alias *> *)aliases {
     return self.async.aliases;
 }
@@ -50,6 +42,14 @@
 
 - (void)clearAccessToken {
     [self.async clearAccessToken];
+}
+
+- (NSArray<Key *> *)getKeys {
+    TKRpcSyncCall<id> *call = [TKRpcSyncCall create];
+    return [call run:^{
+        [self.async getKeys:call.onSuccess
+                    onError:call.onError];
+    }];
 }
 
 - (void)approveKey:(Key *)key {

--- a/src/api/TKMemberSync.m
+++ b/src/api/TKMemberSync.m
@@ -33,7 +33,11 @@
 }
 
 - (NSArray<Key *> *)keys {
-    return self.async.keys;
+    TKRpcSyncCall<id> *call = [TKRpcSyncCall create];
+    return [call run:^{
+        [self.async getKeys:call.onSuccess
+                    onError:call.onError];
+    }];
 }
 
 - (NSArray<Alias *> *)aliases {

--- a/src/api/TKTypedef.h
+++ b/src/api/TKTypedef.h
@@ -26,6 +26,7 @@
 @class Pricing;
 @class Profile;
 @class Alias;
+@class Key;
 @class TokenMember;
 @class MemberRecoveryOperation;
 @class ExternalAuthorizationDetails;
@@ -42,6 +43,8 @@ typedef void (^ _Nonnull OnSuccessWithString)(NSString * _Nullable);
 
 typedef void (^ _Nonnull OnSuccessWithMember)(Member * _Nonnull);
 typedef void (^ _Nonnull OnSuccessWithTKMember)(TKMember * _Nonnull);
+
+typedef void (^ _Nonnull OnSuccessWithKeys)(NSArray<Key *> * _Nonnull);
 
 typedef void (^ _Nonnull OnSuccessWithAliases)(NSArray<Alias *> * _Nonnull);
 

--- a/tests/TKMemberRegistrationTests.m
+++ b/tests/TKMemberRegistrationTests.m
@@ -20,7 +20,7 @@
         TKMemberSync *member = [tokenIO createMember:alias];
         XCTAssert(member.id.length > 0);
         XCTAssertEqualObjects(member.firstAlias, alias);
-        XCTAssertEqual(member.keys.count, 3);
+        XCTAssertEqual([member getKeys].count, 3);
         
         [member deleteMember];
         XCTAssertThrows([tokenIO getMember:member.id]);
@@ -48,7 +48,7 @@
 
         TKMemberSync *memberNewDevice = [tokenIO getMember:newDevice.memberId];
         XCTAssertEqualObjects(member.firstAlias, memberNewDevice.firstAlias);
-        XCTAssertEqual(memberNewDevice.keys.count, 6); // 3 keys per device.
+        XCTAssertEqual([memberNewDevice getKeys].count, 6); // 3 keys per device.
     }];
 }
 
@@ -56,7 +56,7 @@
     [self run: ^(TokenIOSync *tokenIO) {
         Alias *alias = [self generateAlias];
         TKMemberSync *member = [tokenIO createMember:alias];
-        XCTAssertEqual(member.keys.count, 3);
+        XCTAssertEqual([member getKeys].count, 3);
         
         id<TKKeyStore> store = [[TKInMemoryKeyStore alloc] init];
         id<TKCryptoEngine> engine = [[TKTokenCryptoEngineFactory factoryWithStore:store
@@ -67,12 +67,11 @@
         [member approveKey:[engine generateKey:Key_Level_Privileged]];
         [member approveKey:[engine generateKey:Key_Level_Standard withExpiration:futureExpriation]];
         
-        XCTAssertEqual(member.keys.count, 5);
+        XCTAssertEqual([member getKeys].count, 5);
         
         // Wait until the key expires
-        [self waitUntil:^{
-            [self check:@"Key should expire" condition:(member.keys.count == 4)];
-        }];
+        sleep(3);
+        XCTAssertEqual([member getKeys].count, 4);
     }];
 }
 
@@ -88,9 +87,9 @@
         [member approveKey:[engine generateKey:Key_Level_Standard]];
         [member approveKey:[engine generateKey:Key_Level_Low]];
         
-        XCTAssertEqual(member.keys.count, 6);
+        XCTAssertEqual([member getKeys].count, 6);
         [member removeNonStoredKeys];
-        XCTAssertEqual(member.keys.count, 3);
+        XCTAssertEqual([member getKeys].count, 3);
     }];
 }
 
@@ -100,7 +99,7 @@
         
         TKMemberSync *loggedIn = [tokenIO getMember:created.id];
         XCTAssert(loggedIn.id.length > 0);
-        XCTAssertEqual(loggedIn.keys.count, 3);
+        XCTAssertEqual([loggedIn getKeys].count, 3);
         XCTAssertEqualObjects(created.firstAlias, loggedIn.firstAlias);
     }];
 }

--- a/tests/TKNotificationsTests.m
+++ b/tests/TKNotificationsTests.m
@@ -156,7 +156,7 @@ void check(NSString *message, BOOL condition) {
 - (void)testGetPairedDevicesUnapprovedKey {
     [self run: ^(TokenIOSync *tokenIO) {
         [payer subscribeToNotifications:@"token" handlerInstructions:instructions];
-        Key *key = [[payerAnotherDevice keys] firstObject];
+        Key *key = [[payerAnotherDevice getKeys] firstObject];
         DeviceMetadata *metadata = [DeviceMetadata message];
         metadata.application = @"Chrome";
         metadata.applicationVersion = @"53.0";
@@ -288,7 +288,7 @@ void check(NSString *message, BOOL condition) {
         [payer subscribeToNotifications:@"token" handlerInstructions:instructions];
 
         
-        Key *key = [[payerAnotherDevice keys] firstObject];
+        Key *key = [[payerAnotherDevice getKeys] firstObject];
         DeviceMetadata *metadata = [DeviceMetadata message];
         metadata.application = @"Chrome";
         metadata.applicationVersion = @"53.0";


### PR DESCRIPTION
Keys can expire and we don't want to return expired keys from the SDK, so we update the member before returning keys.

@sibinlu Are there any usages of the old asynchronous keys method in the app? Because this PR removes that...