### PR TITLE
add skip tests options in xcodebuild

### DIFF
--- a/TokenSdk.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/TokenSdk.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/bin/run-tests
+++ b/bin/run-tests
@@ -1,11 +1,15 @@
 #!/bin/bash
 
+scheme=$1
+
 destination=$(instruments -s devices | grep iPhone | tail -1 \
      | sed 's/\(iPhone[^\(]*\) (\([0-9.]*\)).*/platform=iOS Simulator,name=\1,OS=\2/')
 
 xcodebuild \
     -workspace TokenSdk.xcworkspace \
-    -scheme "All Tests" \
+    -scheme "${scheme}" \
     -sdk iphonesimulator \
     -destination "${destination}" \
+    -skip-testing:TokenSdkTests/TKAccountSamples/testBankAuthorizationNotification  \
+    -skip-testing:TokenSdkTests/TKAccountSamples/testInitiateAccountLinking  \
     test

--- a/bin/run-tests-local
+++ b/bin/run-tests-local
@@ -5,4 +5,4 @@ set -o nounset
 
 dir=$(dirname $0)
 
-${dir}/run-tests "All Tests - AWS Development"
+${dir}/run-tests "All Tests"

--- a/bin/run-tests-sandbox
+++ b/bin/run-tests-sandbox
@@ -1,11 +1,9 @@
 #!/bin/bash
 
-destination=$(instruments -s devices | grep iPhone | tail -1 \
-     | sed 's/\(iPhone[^\(]*\) (\([0-9.]*\)).*/platform=iOS Simulator,name=\1,OS=\2/')
+set -o errexit
+set -o nounset
 
-xcodebuild \
-    -workspace TokenSdk.xcworkspace \
-    -scheme "All Tests - AWS Sandbox" \
-    -sdk iphonesimulator \
-    -destination "${destination}" \
-    test
+dir=$(dirname $0)
+
+${dir}/run-tests "All Tests - AWS Sandbox"
+#!/bin/bash

--- a/bin/run-tests-sandbox
+++ b/bin/run-tests-sandbox
@@ -6,4 +6,3 @@ set -o nounset
 dir=$(dirname $0)
 
 ${dir}/run-tests "All Tests - AWS Sandbox"
-#!/bin/bash

--- a/bin/run-tests-stg
+++ b/bin/run-tests-stg
@@ -1,11 +1,8 @@
 #!/bin/bash
 
-destination=$(instruments -s devices | grep iPhone | tail -1 \
-     | sed 's/\(iPhone[^\(]*\) (\([0-9.]*\)).*/platform=iOS Simulator,name=\1,OS=\2/')
+set -o errexit
+set -o nounset
 
-xcodebuild \
-    -workspace TokenSdk.xcworkspace \
-    -scheme "All Tests - AWS Staging" \
-    -sdk iphonesimulator \
-    -destination "${destination}" \
-    test
+dir=$(dirname $0)
+
+${dir}/run-tests "All Tests - AWS Staging"


### PR DESCRIPTION
After update to Xcodebuild version 10E1001, it can not handle the disabled tests correctly in the build schema. Explicitly set it in build script can bypass the problem.

IDEWorkspaceChecks.plist is a file generated by new version Xcode and is suggested to persist in source control by Apple.